### PR TITLE
去除 Spring 包对 JavaEE 注解 javax.annotation.PostConstruct 的依赖

### DIFF
--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/SmartWebEndpointMappingFactoryTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/SmartWebEndpointMappingFactoryTest.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.web.metadata;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -25,7 +26,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import javax.annotation.PostConstruct;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -51,7 +51,7 @@ public class SmartWebEndpointMappingFactoryTest {
 
     private String fullJson;
 
-    @PostConstruct
+    @BeforeEach
     public void init() throws Throwable {
         this.fullJson = copyToString(this.fullJsonResource.getInputStream(), UTF_8);
     }

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.web.metadata;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -25,7 +26,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Kind.CUSTOMIZED;
@@ -49,7 +49,7 @@ public class WebEndpointMappingTest {
 
     private String fullJson;
 
-    @PostConstruct
+    @BeforeEach
     public void init() throws Throwable {
         this.fullJson = copyToString(this.fullJsonResource.getInputStream(), UTF_8);
     }


### PR DESCRIPTION
去除 Spring 包中单元测试代码对 JavaEE 注解 javax.annotation.PostConstruct 的依赖，统一使用 @BeforeEach 处理初始化，以支持 JDK11+ 编译，并统一单元测试初始化方式。