### PR TITLE
ConfigurationBean支持刷新

### DIFF
--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
@@ -46,6 +46,7 @@ public class ConfigurationBeanBindingsRegister implements ImportBeanDefinitionRe
         ConfigurationBeanBindingRegistrar registrar = new ConfigurationBeanBindingRegistrar();
 
         registrar.setEnvironment(environment);
+        registrar.registerRefreshableConfigurationBeanRepository(registry);
 
         for (AnnotationAttributes element : annotationAttributes) {
             registrar.registerConfigurationBeanDefinitions(element, registry);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/EnableConfigurationBeanBinding.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/EnableConfigurationBeanBinding.java
@@ -105,4 +105,34 @@ public @interface EnableConfigurationBeanBinding {
      * @see #DEFAULT_IGNORE_INVALID_FIELDS
      */
     boolean ignoreInvalidFields() default DEFAULT_IGNORE_INVALID_FIELDS;
+
+    /**
+     * set the refresh strategy for target configuration
+     * @return the refresh strategy
+     * @see ConfigurationBeanRefreshStrategy
+     */
+    ConfigurationBeanRefreshStrategy refreshStrategy() default ConfigurationBeanRefreshStrategy.REBIND;
+
+    /**
+     * define refresh strategy for Configuration Bean
+     *
+     * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+     * @see RefreshableConfigurationBeans
+     * @since 1.0.0
+     */
+    enum ConfigurationBeanRefreshStrategy {
+        /**
+         * disabled refresh, and the configuration bean will be immutable
+         */
+        DISABLED,
+
+        /**
+         * just rebind properties
+         */
+        REBIND,
+        /**
+         * destroy bean and reinitialize
+         */
+        REINITIALIZE;
+    }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeanPredicate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeanPredicate.java
@@ -1,0 +1,15 @@
+package io.microsphere.spring.beans.factory.annotation;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+
+/**
+ * the filter for {@link RefreshableConfigurationBeans}
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface RefreshableConfigurationBeanPredicate {
+
+    boolean support(String beanName, Object instance, BeanDefinition beanDefinition);
+
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeans.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeans.java
@@ -1,0 +1,242 @@
+package io.microsphere.spring.beans.factory.annotation;
+
+import io.microsphere.spring.context.config.ConfigurationBeanBinder;
+import io.microsphere.spring.context.config.DefaultConfigurationBeanBinder;
+import io.microsphere.spring.context.event.ConfigurationBeanRefreshedEvent;
+import io.microsphere.spring.core.convert.support.ConversionServiceResolver;
+import io.microsphere.spring.util.PropertySourcesUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.*;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.util.Assert;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.microsphere.spring.context.config.ConfigurationBeanBinder.*;
+
+/**
+ * collect Configuration Beans in current context and its parent.<br/>
+ * also provider {@link RefreshableConfigurationBeans#refreshByName(String, boolean)} operation for refresh special bean
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0.0
+ */
+@ManagedResource
+public class RefreshableConfigurationBeans implements ApplicationContextAware, EnvironmentAware, ApplicationEventPublisherAware {
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    public static final String BEAN_NAME = "refreshableConfigurationBeans";
+
+    private final Map<String, Object> beans = new ConcurrentHashMap<>(64);
+    private final Map<String, String> prefixToBeanNames = new ConcurrentHashMap<>(64);
+    private ApplicationContext applicationContext;
+    private ConfigurableListableBeanFactory beanFactory;
+    private ConfigurableEnvironment environment;
+    private ApplicationEventPublisher eventPublisher;
+    private volatile ConfigurationBeanBinder configurationBeanBinder;
+    private final Collection<RefreshableConfigurationBeanPredicate> filters = new ArrayList<>();
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+        Assert.isInstanceOf(ConfigurableListableBeanFactory.class, applicationContext.getAutowireCapableBeanFactory());
+        this.beanFactory = (ConfigurableListableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
+        this.filters.addAll(BeanFactoryUtils.beansOfTypeIncludingAncestors(this.beanFactory, RefreshableConfigurationBeanPredicate.class).values());
+    }
+
+    public void registerConfigurationBean(String beanName, Object instance, BeanDefinition beanDefinition) {
+        EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy refreshStrategy = (EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy) beanDefinition.getAttribute(ConfigurationBeanBinder.CONFIGURATION_BEAN_REFRESH_STRATEGY);
+        if (refreshStrategy == EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy.DISABLED) {
+            log.debug("bean [name=" + beanName + "] disable refresh");
+            return;
+        }
+
+        synchronized (this.filters) {
+            for (RefreshableConfigurationBeanPredicate filter : this.filters) {
+                if (!filter.support(beanName, instance, beanDefinition)) {
+                    log.debug("bean [name=" + beanName + "] is not supported");
+                    return;
+                }
+            }
+        }
+
+        this.beans.put(beanName, instance);
+        String prefix = (String) beanDefinition.getAttribute(CONFIGURATION_PREFIX_ATTRIBUTE_NAME);
+        boolean usingMultiple = (Boolean) beanDefinition.getAttribute(USING_MULTIPLE_CONFIGURATION_ATTRIBUTE_NAME);
+        if (usingMultiple) {
+            prefix = prefix + '.' + beanName;
+        }
+        this.prefixToBeanNames.put(prefix, beanName);
+    }
+
+
+    public void addFilter(RefreshableConfigurationBeanPredicate filter) {
+        synchronized (this.filters) {
+            if (filter != null)
+                this.filters.add(filter);
+        }
+    }
+
+
+
+    /**
+     * @return all bean names
+     */
+    @ManagedAttribute
+    public Set<String> managedBeanNames() {
+        return Collections.unmodifiableSet(this.beans.keySet());
+    }
+
+    /**
+     *
+     * @return all prefixes
+     */
+    @ManagedAttribute
+    public Set<String> managedPrefixes() {
+        return Collections.unmodifiableSet(this.prefixToBeanNames.keySet());
+    }
+
+    public ConfigurationBeanBinder getConfigurationBeanBinder() {
+        if (this.configurationBeanBinder == null)
+            initConfigurationBeanBinder();
+        return this.configurationBeanBinder;
+    }
+
+    private void initConfigurationBeanBinder() {
+        ConfigurationBeanBinder configurationBeanBinder = this.configurationBeanBinder;
+        if (configurationBeanBinder == null) {
+            try {
+                configurationBeanBinder = beanFactory.getBean(ConfigurationBeanBinder.class);
+            } catch (BeansException ignored) {
+                if (log.isInfoEnabled()) {
+                    log.info("configurationBeanBinder Bean can't be found in ApplicationContext.");
+                }
+                // Use Default implementation
+                configurationBeanBinder = new DefaultConfigurationBeanBinder();
+            }
+        }
+
+        ConversionService conversionService = new ConversionServiceResolver(beanFactory).resolve();
+        configurationBeanBinder.setConversionService(conversionService);
+
+        this.configurationBeanBinder = configurationBeanBinder;
+    }
+
+    /**
+     * refresh the special configuration bean
+     * @param name the special configuration bean name
+     * @param notifyEvent should send {@link ConfigurationBeanRefreshedEvent}
+     */
+    @ManagedOperation
+    public void refreshByName(String name, boolean notifyEvent) {
+        //check exists
+        Object instance = this.beans.get(name);
+        if (instance == null) {
+            log.debug("ConfigurationBean[name= " + name +"] not registered, please check refreshStrategy is enabled?");
+            return;
+        }
+        BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(name);
+        EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy strategy = (EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy)beanDefinition.getAttribute(CONFIGURATION_BEAN_REFRESH_STRATEGY);
+        Map<String, Object> previousConfigurationProperties = (Map<String, Object>) beanDefinition.getAttribute(CONFIGURATION_PROPERTIES_ATTRIBUTE_NAME);
+
+
+
+
+        //override configuration properties
+        String prefix = (String) beanDefinition.getAttribute(CONFIGURATION_PREFIX_ATTRIBUTE_NAME);
+        boolean multiple = (Boolean) beanDefinition.getAttribute(USING_MULTIPLE_CONFIGURATION_ATTRIBUTE_NAME);
+        if (multiple) {
+            prefix = prefix + '.' + name;
+        }
+        Map<String, Object> configurationProperties = PropertySourcesUtils.getSubProperties(environment.getPropertySources(), environment, prefix);
+        beanDefinition.setAttribute(CONFIGURATION_PROPERTIES_ATTRIBUTE_NAME, configurationProperties);
+        switch (strategy) {
+            case DISABLED:
+                log.info("bean [" + name + "] has disabled refresh");
+                return;
+            case REINITIALIZE:
+                refreshAndReinitialized(name, instance, beanDefinition);
+                if (notifyEvent)
+                    notifyConfigurationBeanRefreshed(name, instance, previousConfigurationProperties);
+                return;
+            case REBIND:
+                //resolve sub properties
+                refreshProperties(name, instance, configurationProperties, beanDefinition);
+                if (notifyEvent)
+                    notifyConfigurationBeanRefreshed(name, instance, previousConfigurationProperties);
+                return;
+            default:
+                //todo throws new exception?
+                log.error("Unknown refresh strategy : " + strategy + " with " + name);
+        }
+    }
+
+    /**
+     * refresh the special configuration bean
+     * @param changedProperty the special configuration property
+     * @param notifyEvent should send {@link ConfigurationBeanRefreshedEvent}
+     */
+    @ManagedOperation
+    public void refreshByProperty(String changedProperty, boolean notifyEvent) {
+        String selectedPrefix = null;
+        Set<String> prefixSet = managedPrefixes();
+        for (String prefix : prefixSet)
+            if (changedProperty.startsWith(prefix)) {
+                selectedPrefix = prefix;
+                break;
+            }
+
+        if (selectedPrefix == null) {
+            log.debug("changedProperty : [" + changedProperty + "] map to prefix : " + selectedPrefix);
+            return;
+        }
+
+
+        final String beanName = this.prefixToBeanNames.get(selectedPrefix);
+        refreshByName(beanName, notifyEvent);
+
+    }
+
+    protected void refreshProperties(String beanName, Object instance, Map<String, Object> configurationProperties, BeanDefinition beanDefinition) {
+        getConfigurationBeanBinder().bind(beanDefinition, instance);
+    }
+
+    protected void refreshAndReinitialized(String beanName, Object instance, BeanDefinition beanDefinition) {
+        try {
+            this.applicationContext.getAutowireCapableBeanFactory().destroyBean(instance);
+            this.applicationContext.getAutowireCapableBeanFactory().initializeBean(instance, beanName);
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot rebind to " + beanName, e);
+        }
+
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+
+        Assert.isInstanceOf(ConfigurableEnvironment.class, environment);
+
+        this.environment = (ConfigurableEnvironment) environment;
+
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.eventPublisher = applicationEventPublisher;
+    }
+
+    private void notifyConfigurationBeanRefreshed(String beanName, Object instance, Map<String, Object> previousConfigurationProperties) {
+        eventPublisher.publishEvent(new ConfigurationBeanRefreshedEvent(beanName, instance, previousConfigurationProperties));
+    }
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/config/ConfigurationBeanBinder.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/config/ConfigurationBeanBinder.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.context.config;
 
 import io.microsphere.spring.beans.factory.annotation.EnableConfigurationBeanBinding;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
@@ -30,6 +31,51 @@ import java.util.Map;
  * @since 1.0.0
  */
 public interface ConfigurationBeanBinder {
+
+    String CONFIGURATION_PREFIX_ATTRIBUTE_NAME = "configurationPrefix";
+
+    String USING_MULTIPLE_CONFIGURATION_ATTRIBUTE_NAME = "multipleConfiguration";
+
+    String CONFIGURATION_PROPERTIES_ATTRIBUTE_NAME = "configurationProperties";
+
+    String IGNORE_UNKNOWN_FIELDS_ATTRIBUTE_NAME = "ignoreUnknownFields";
+
+    String IGNORE_INVALID_FIELDS_ATTRIBUTE_NAME = "ignoreInvalidFields";
+
+    String CONFIGURATION_BEAN_REFRESH_STRATEGY = "refreshStrategy";
+
+    /**
+     * Bind the properties in the {@link Environment} to Configuration bean under specified prefix.
+     *
+     * @param beanDefinition     bean definition
+     * @param configurationBean       the bean of configuration
+     */
+    default void bind(BeanDefinition beanDefinition, Object configurationBean) {
+        if (beanDefinition == null || configurationBean == null)
+            return;
+
+        Map<String, Object> configurationProperties = (Map<String, Object>) beanDefinition.getAttribute(CONFIGURATION_PROPERTIES_ATTRIBUTE_NAME);
+
+        bind(configurationProperties, beanDefinition, configurationBean);
+    }
+
+    /**
+     * Bind the properties in the {@link Environment} to Configuration bean under specified prefix.
+     *
+     * @param configurationProperties the special configuration properties
+     * @param beanDefinition     bean definition
+     * @param configurationBean       the bean of configuration
+     */
+    default void bind(Map<String, Object> configurationProperties, BeanDefinition beanDefinition, Object configurationBean) {
+        if (beanDefinition == null || configurationBean == null)
+            return;
+
+        boolean ignoreUnknownFields = (Boolean) beanDefinition.getAttribute(IGNORE_UNKNOWN_FIELDS_ATTRIBUTE_NAME);
+
+        boolean ignoreInvalidFields = (Boolean) beanDefinition.getAttribute(IGNORE_INVALID_FIELDS_ATTRIBUTE_NAME);
+
+        bind(configurationProperties, ignoreUnknownFields, ignoreInvalidFields, configurationBean);
+    }
 
     /**
      * Bind the properties in the {@link Environment} to Configuration bean under specified prefix.

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/ConfigurationBeanRefreshedEvent.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/ConfigurationBeanRefreshedEvent.java
@@ -1,0 +1,35 @@
+package io.microsphere.spring.context.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0.0
+ */
+public class ConfigurationBeanRefreshedEvent extends ApplicationEvent {
+
+    private final String beanName;
+    private final Object configurationBean;
+    private final Map<String, Object> previousConfigurationProperties;
+
+    public ConfigurationBeanRefreshedEvent(String beanName, Object configurationBean, Map<String, Object> previousConfigurationProperties) {
+        super(configurationBean);
+        this.beanName = beanName;
+        this.configurationBean = configurationBean;
+        this.previousConfigurationProperties = previousConfigurationProperties;
+    }
+
+    public String getBeanName() {
+        return beanName;
+    }
+
+    public Object getConfigurationBean() {
+        return configurationBean;
+    }
+
+    public Map<String, Object> getPreviousConfigurationProperties() {
+        return previousConfigurationProperties;
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeansTestFilter.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/annotation/RefreshableConfigurationBeansTestFilter.java
@@ -1,0 +1,53 @@
+package io.microsphere.spring.beans.factory.annotation;
+
+import io.microsphere.spring.context.event.ConfigurationBeanRefreshedEvent;
+import io.microsphere.spring.util.User;
+import org.junit.Test;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+@EnableConfigurationBeanBinding(prefix = "usr", type = User.class, refreshStrategy = EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy.REINITIALIZE)
+@EnableConfigurationBeanBinding(prefix = "users", type = User.class, multiple = true, ignoreUnknownFields = false,
+        ignoreInvalidFields = false)
+@EnableMBeanExport
+public class RefreshableConfigurationBeansTestFilter extends AbstractEnableConfigurationBeanBindingTest implements ApplicationListener<ConfigurationBeanRefreshedEvent> {
+
+    private final MapPropertySource override = new MapPropertySource("override", new HashMap<>());
+
+    protected void overrideConfigurations(String key, String value) {
+        MutablePropertySources propertySources = context.getEnvironment().getPropertySources();
+        MapPropertySource propertySource = (MapPropertySource) propertySources.get("modify");
+        if (propertySource == null) {
+            propertySources.addFirst(override);
+        }
+        override.getSource().put(key, value);
+
+    }
+
+    @Test
+    public void testRefresh() {
+        User user = context.getBean("m", User.class);
+        assertEquals("mercyblitz", user.getName());
+        assertEquals(34, user.getAge());
+
+        RefreshableConfigurationBeans refreshableConfigurationBeans = context.getBean(RefreshableConfigurationBeans.class);
+
+        overrideConfigurations("usr.age", "26");
+        refreshableConfigurationBeans.refreshByName("m", true);
+        assertEquals(26, user.getAge());
+
+        overrideConfigurations("users.a.name", "override-user-a");
+        refreshableConfigurationBeans.refreshByProperty("users.a.name", true);
+    }
+
+    @Override
+    public void onApplicationEvent(ConfigurationBeanRefreshedEvent event) {
+        System.out.println("received ConfigurationBeanRefreshedEvent for bean :" + event.getBeanName());
+    }
+}


### PR DESCRIPTION
允许程序运行时刷新ConfigurationBean属性,支持3种刷新策略
1. DISABLED, 激活时不会触发刷新操作,此时认为Bean是不可变的
2. REBIND, 激活时,刷新只会修改关联配置值(默认值)
3. REINITIALIZE,激活时,不止刷新属性,还会将当前Bean销毁掉并重新初始化

参考示例:
```java
@EnableConfigurationBeanBinding(prefix = "usr", type = User.class, refreshStrategy = EnableConfigurationBeanBinding.ConfigurationBeanRefreshStrategy.REINITIALIZE)
@EnableConfigurationBeanBinding(prefix = "users", type = User.class, multiple = true, ignoreUnknownFields = false,
        ignoreInvalidFields = false)
```

支持JMX操作
`RefreshableConfigurationBeans`
```java
@ManagedAttribute
public Set<String> managedBeanNames();

@ManagedAttribute
public Set<String> managedPrefixes();

@ManagedOperation
public void refreshByName(String name, boolean notifyEvent);

@ManagedOperation
public void refreshByProperty(String changedProperty, boolean notifyEvent);
```

事件支持
`ConfigurationBeanRefreshedEvent`
