### PR TITLE
Refactor branch 1.x

### DIFF
--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static io.microsphere.collection.MapUtils.newConcurrentHashMap;
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.findPrimaryConstructor;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
@@ -74,7 +75,6 @@ import static java.lang.Integer.getInteger;
 import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOf;
-import static java.util.Collections.singleton;
 import static java.util.Collections.unmodifiableCollection;
 import static org.springframework.beans.BeanUtils.findPropertyForMethod;
 import static org.springframework.beans.factory.annotation.InjectionMetadata.needsRefresh;
@@ -231,7 +231,7 @@ public class AnnotatedInjectionBeanPostProcessor extends InstantiationAwareBeanP
      * @param annotationType the single type of {@link Annotation annotation}
      */
     public AnnotatedInjectionBeanPostProcessor(Class<? extends Annotation> annotationType, Class<? extends Annotation>... otherAnnotationTypes) {
-        this(combine(singleton(annotationType), asList(otherAnnotationTypes)));
+        this(combine(ofSet(annotationType), asList(otherAnnotationTypes)));
     }
 
     /**

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.annotation.ConfigurationBeanBindingPostProcessor.initBeanMetadataAttributes;
 import static io.microsphere.spring.beans.factory.annotation.EnableConfigurationBeanBinding.DEFAULT_IGNORE_INVALID_FIELDS;
@@ -50,7 +51,6 @@ import static io.microsphere.spring.core.env.PropertySourcesUtils.getSubProperti
 import static io.microsphere.spring.core.env.PropertySourcesUtils.normalizePrefix;
 import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactories;
 import static java.lang.Boolean.valueOf;
-import static java.util.Collections.singleton;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
 import static org.springframework.beans.factory.support.BeanDefinitionReaderUtils.generateBeanName;
 import static org.springframework.util.StringUtils.hasText;
@@ -141,7 +141,7 @@ public class ConfigurationBeanBindingRegistrar implements ImportBeanDefinitionRe
         Map<String, Object> configurationProperties = getSubProperties(environment.getPropertySources(), environment, prefix);
 
         Set<String> beanNames = multiple ? resolveMultipleBeanNames(configurationProperties) :
-                singleton(resolveSingleBeanName(configurationProperties, configClass, registry));
+                ofSet(resolveSingleBeanName(configurationProperties, configClass, registry));
 
         for (String beanName : beanNames) {
             registerConfigurationBean(beanName, configClass, multiple, ignoreUnknownFields, ignoreInvalidFields,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java
@@ -49,13 +49,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.config.env.event.PropertySourceChangedEvent.added;
 import static io.microsphere.spring.config.env.event.PropertySourceChangedEvent.replaced;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ArrayUtils.isEmpty;
 import static io.microsphere.util.StringUtils.EMPTY_STRING_ARRAY;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
 import static java.util.Collections.sort;
 import static org.springframework.beans.BeanUtils.instantiateClass;
 import static org.springframework.core.ResolvableType.forType;
@@ -275,7 +275,7 @@ public abstract class PropertySourceExtensionLoader<A extends Annotation, EA ext
         if (resource.exists()) { // Resource exists
             PropertySourceResource propertySourceResource = createPropertySourceResource(resourceValue, resource, resourceComparator);
             ResourcePropertySource newResourcePropertySource = createResourcePropertySource(extensionAttributes, propertySourceName, factory, propertySourceResource);
-            updateResourcePropertySources(singleton(newResourcePropertySource), resourcePropertySources, subEvents);
+            updateResourcePropertySources(ofSet(newResourcePropertySource), resourcePropertySources, subEvents);
         } else {
             removeResourcePropertySource(propertySourceName, resourceValue, resource, resourcePropertySources, subEvents);
         }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/DependencyAnalysisBeanFactoryListener.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/DependencyAnalysisBeanFactoryListener.java
@@ -51,6 +51,7 @@ import java.util.function.Supplier;
 
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.collection.ListUtils.newLinkedList;
+import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.reflect.TypeUtils.isParameterizedType;
 import static io.microsphere.reflect.TypeUtils.resolveActualTypeArgumentClasses;
@@ -61,7 +62,6 @@ import static io.microsphere.util.ArrayUtils.EMPTY_PARAMETER_ARRAY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonList;
 import static org.springframework.util.ClassUtils.resolveClassName;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
@@ -297,7 +297,7 @@ public class DependencyAnalysisBeanFactoryListener implements BeanFactoryListene
             String[] beanNames = beanFactory.getBeanNamesForType(dependentType, false, false);
             return asList(beanNames);
         } else {
-            return singletonList(dependentBeanName);
+            return ofList(dependentBeanName);
         }
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
@@ -4,7 +4,6 @@ import io.microsphere.spring.beans.BeanUtils.NamingBean;
 import io.microsphere.spring.beans.test.TestBean;
 import io.microsphere.spring.beans.test.TestBean2;
 import io.microsphere.spring.test.domain.User;
-import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -34,6 +33,7 @@ import static io.microsphere.spring.beans.BeanUtils.sort;
 import static io.microsphere.spring.context.annotation.AnnotatedBeanDefinitionRegistryUtils.registerBeans;
 import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -301,7 +301,7 @@ public class BeanUtilsTest {
 
         Map<String, OrderedBean> sortedBeansMap = sort(orderedBeansMap);
 
-        Assert.assertArrayEquals(expectedBeansMap.values().toArray(), sortedBeansMap.values().toArray());
+        assertArrayEquals(expectedBeansMap.values().toArray(), sortedBeansMap.values().toArray());
 
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/annotation/EnableConfigurationBeanBindingTestForAlias.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/annotation/EnableConfigurationBeanBindingTestForAlias.java
@@ -3,10 +3,8 @@ package io.microsphere.spring.beans.factory.annotation;
 import io.microsphere.spring.test.domain.User;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtilsTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.doGetResolvableType;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.findBeanNames;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.findInfrastructureBeanNames;
@@ -50,7 +51,6 @@ import static io.microsphere.spring.core.SpringVersion.SPRING_5_0;
 import static io.microsphere.spring.core.SpringVersion.SPRING_5_1;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -293,7 +293,7 @@ public class BeanDefinitionUtilsTest {
 
         @Bean(name = USERS_BEAN_NAME)
         public List<User> users() {
-            return singletonList(new User());
+            return ofList(new User());
         }
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/filter/ResolvableDependencyTypeFilterTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/filter/ResolvableDependencyTypeFilterTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -78,9 +79,9 @@ public class ResolvableDependencyTypeFilterTest {
         assertFalse(filter.accept(getClass()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAcceptOnNPE() {
-        filter.accept(null);
+        assertThrows(NullPointerException.class, () -> filter.accept(null));
     }
 
     @Test

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/cache/annotation/EnableTTLCachingTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/cache/annotation/EnableTTLCachingTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.Collection;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
+import static io.microsphere.collection.Lists.ofList;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
@@ -49,7 +49,7 @@ public class EnableTTLCachingTest {
 
     @Bean
     public static CacheManager cacheManager() {
-        Collection<? extends Cache> caches = singletonList(new ConcurrentMapCache("test"));
+        Collection<? extends Cache> caches = ofList(new ConcurrentMapCache("test"));
         SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
         simpleCacheManager.setCaches(caches);
         return simpleCacheManager;
@@ -58,7 +58,7 @@ public class EnableTTLCachingTest {
     static class TestData {
         @TTLCacheable(cacheNames = "test", timeUnit = MINUTES, expire = 1)
         public List<String> getNames() {
-            return singletonList("a");
+            return ofList("a");
         }
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionAttributesTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -62,9 +63,9 @@ public class PropertySourceExtensionAttributesTest {
         assertSame(annotationType, validateAnnotationType(annotationType));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidateAnnotationTypeOnIllegalArgumentException() {
-        validateAnnotationType(Override.class);
+        assertThrows(IllegalArgumentException.class, () -> validateAnnotationType(Override.class));
     }
 
     @Test

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
@@ -51,6 +51,7 @@ import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME;
@@ -127,10 +128,11 @@ public class ResourcePropertySourceLoaderTest {
         }, IgnoreResourceNotFoundConfig.class);
     }
 
-    @Test(expected = BeanDefinitionStoreException.class)
+    @Test
     public void testOnNotFoundConfig() {
-        testInSpringContainer((context, environment) -> {
-        }, NotFoundConfig.class);
+        assertThrows(BeanDefinitionStoreException.class,
+                () -> testInSpringContainer((context, environment) -> {
+                }, NotFoundConfig.class));
     }
 
     @Test

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/config/env/annotation/YamlPropertySourceTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/config/env/annotation/YamlPropertySourceTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Date;
 import java.util.Objects;

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/MethodParameterUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/MethodParameterUtilsTest.java
@@ -35,6 +35,7 @@ import static io.microsphere.spring.core.MethodParameterUtils.forExecutable;
 import static io.microsphere.spring.core.MethodParameterUtils.forParameter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 /**
  * {@link MethodParameterUtils} Test
@@ -76,9 +77,9 @@ public class MethodParameterUtilsTest {
         assertMethodParameter(methodParameter);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testForNullExecutable() {
-        forExecutable(null, -1);
+        assertThrows(IllegalArgumentException.class, () -> forExecutable(null, -1));
     }
 
     void assertMethodParameter(MethodParameter methodParameter) {
@@ -101,11 +102,11 @@ public class MethodParameterUtilsTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFindParameterIndexOnIllegalArgumentException() throws Throwable {
         Method waitMethod = findMethod(Object.class, "wait", long.class, int.class);
         Parameter clonedParameter = clone(waitMethod.getParameters()[1], findMethod(User.class, "getName"), 0);
-        findParameterIndex(clonedParameter);
+        assertThrows(IllegalArgumentException.class, () -> findParameterIndex(clonedParameter));
     }
 
     void assertParameters(Class<?> klass) throws Throwable {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/env/PropertySourcesUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/env/PropertySourcesUtilsTest.java
@@ -15,7 +15,6 @@ import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.env.MockPropertySource;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/net/AbstractSpringResourceURLConnectionTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/net/AbstractSpringResourceURLConnectionTest.java
@@ -34,7 +34,6 @@ import static java.lang.System.currentTimeMillis;
 import static java.net.URLConnection.getDefaultAllowUserInteraction;
 import static java.net.URLConnection.setDefaultAllowUserInteraction;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -195,7 +194,7 @@ public abstract class AbstractSpringResourceURLConnectionTest {
         String name = "name";
         String value = "value";
         adapter.addHeader(name, value);
-        assertEquals(singletonMap(name, singletonList(value)), adapter.getHeaderFields());
+        assertEquals(singletonMap(name, ofList(value)), adapter.getHeaderFields());
     }
 
     void testGetPermission(URLConnection urlConnection) throws IOException {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/net/SpringResourceURLConnectionAdapterTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/net/SpringResourceURLConnectionAdapterTest.java
@@ -28,12 +28,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 
+import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static io.microsphere.util.ClassLoaderUtils.getClassResource;
 import static java.net.URLConnection.getDefaultAllowUserInteraction;
 import static java.net.URLConnection.setDefaultAllowUserInteraction;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -267,7 +267,7 @@ public class SpringResourceURLConnectionAdapterTest extends AbstractSpringResour
         String name = "name";
         String value = "value";
         adapter.addHeader(name, value);
-        assertEquals(singletonMap(name, singletonList(value)), adapter.getHeaderFields());
+        assertEquals(singletonMap(name, ofList(value)), adapter.getHeaderFields());
     }
 
     @Override

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/util/MimeTypeUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/util/MimeTypeUtilsTest.java
@@ -19,6 +19,7 @@ package io.microsphere.spring.util;
 import org.junit.Test;
 import org.springframework.util.MimeType;
 
+import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.spring.util.MimeTypeUtils.APPLICATION_GRAPHQL;
 import static io.microsphere.spring.util.MimeTypeUtils.APPLICATION_GRAPHQL_VALUE;
 import static io.microsphere.spring.util.MimeTypeUtils.equalsTypeAndSubtype;
@@ -26,7 +27,6 @@ import static io.microsphere.spring.util.MimeTypeUtils.getSubtypeSuffix;
 import static io.microsphere.spring.util.MimeTypeUtils.isPresentIn;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -74,8 +74,8 @@ public class MimeTypeUtilsTest {
     public void testIsPresentIn() {
         assertFalse(isPresentIn(APPLICATION_GRAPHQL, null));
         assertFalse(isPresentIn(APPLICATION_GRAPHQL, emptyList()));
-        assertFalse(isPresentIn(APPLICATION_GRAPHQL, singletonList(APPLICATION_TEXT)));
+        assertFalse(isPresentIn(APPLICATION_GRAPHQL, ofList(APPLICATION_TEXT)));
         assertTrue(isPresentIn(APPLICATION_GRAPHQL, asList(APPLICATION_TEXT, APPLICATION_GRAPHQL)));
-        assertTrue(isPresentIn(APPLICATION_GRAPHQL, singletonList(APPLICATION_GRAPHQL)));
+        assertTrue(isPresentIn(APPLICATION_GRAPHQL, ofList(APPLICATION_GRAPHQL)));
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/util/SpringVersionUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/util/SpringVersionUtilsTest.java
@@ -28,6 +28,7 @@ import static io.microsphere.spring.util.SpringVersionUtils.SPRING_CONTEXT_VERSI
 import static io.microsphere.spring.util.SpringVersionUtils.SPRING_CORE_VERSION;
 import static io.microsphere.spring.util.SpringVersionUtils.getSpringVersion;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * {@link SpringVersionUtils} Test
@@ -37,14 +38,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class SpringVersionUtilsTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetSpringVersionOnNPE() {
-        getSpringVersion((Class) null);
+        assertThrows(NullPointerException.class, () -> getSpringVersion((Class) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetSpringVersionOnIAE() {
-        getSpringVersion(String.class);
+        assertThrows(IllegalArgumentException.class, () -> getSpringVersion(String.class));
     }
 
     @Test

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/GenericMediaTypeExpression.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/GenericMediaTypeExpression.java
@@ -20,6 +20,7 @@ import io.microsphere.annotation.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import static org.springframework.http.MediaType.SPECIFICITY_COMPARATOR;
 import static org.springframework.http.MediaType.parseMediaType;
 
 /**
@@ -78,7 +79,7 @@ public class GenericMediaTypeExpression implements MediaTypeExpression, Comparab
 
     @Override
     public int compareTo(GenericMediaTypeExpression other) {
-        return MediaType.SPECIFICITY_COMPARATOR.compare(this.getMediaType(), other.getMediaType());
+        return SPECIFICITY_COMPARATOR.compare(this.getMediaType(), other.getMediaType());
     }
 
     @Override

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestMethodsRule.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestMethodsRule.java
@@ -29,7 +29,6 @@ import static io.microsphere.spring.web.util.WebRequestUtils.getMethod;
 import static io.microsphere.spring.web.util.WebRequestUtils.isPreFlightRequest;
 import static io.microsphere.util.ArrayUtils.combine;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.of;
 import static org.springframework.web.bind.annotation.RequestMethod.OPTIONS;
@@ -56,7 +55,7 @@ public class WebRequestMethodsRule extends AbstractWebRequestRule<String> {
     }
 
     public WebRequestMethodsRule(String method, String... others) {
-        this.methods = ObjectUtils.isEmpty(others) ? singleton(method) : ofSet(combine(method, others));
+        this.methods = ObjectUtils.isEmpty(others) ? ofSet(method) : ofSet(combine(method, others));
     }
 
     @Override

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestPattensRule.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestPattensRule.java
@@ -29,11 +29,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.web.util.WebRequestUtils.getResolvedLookupPath;
 import static io.microsphere.spring.web.util.WebRequestUtils.isPreFlightRequest;
 import static io.microsphere.util.ArrayUtils.isNotEmpty;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
 import static org.springframework.util.StringUtils.hasLength;
 import static org.springframework.util.StringUtils.hasText;
 
@@ -54,7 +54,7 @@ import static org.springframework.util.StringUtils.hasText;
  */
 public class WebRequestPattensRule extends AbstractWebRequestRule<String> {
 
-    private final static Set<String> EMPTY_PATH_PATTERN = singleton("");
+    private final static Set<String> EMPTY_PATH_PATTERN = ofSet("");
 
     private final Set<String> patterns;
 

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestProducesRule.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/rule/WebRequestProducesRule.java
@@ -32,10 +32,8 @@ import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.spring.util.MimeTypeUtils.isPresentIn;
 import static io.microsphere.spring.web.rule.ProduceMediaTypeExpression.parseExpressions;
 import static io.microsphere.spring.web.util.WebRequestUtils.isPreFlightRequest;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.sort;
 import static org.springframework.http.MediaType.ALL;
-import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
 
@@ -61,8 +59,7 @@ public class WebRequestProducesRule extends AbstractWebRequestRule<ProduceMediaT
     private static final ContentNegotiationManager DEFAULT_CONTENT_NEGOTIATION_MANAGER =
             new ContentNegotiationManager();
 
-    private static final List<ProduceMediaTypeExpression> MEDIA_TYPE_ALL_LIST =
-            singletonList(new ProduceMediaTypeExpression(ALL_VALUE));
+    // private static final List<ProduceMediaTypeExpression> MEDIA_TYPE_ALL_LIST = ofList(new ProduceMediaTypeExpression(ALL_VALUE));
 
     private static final String MEDIA_TYPES_ATTRIBUTE = WebRequestProducesRule.class.getName() + ".MEDIA_TYPES";
 

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/AbstractWebRequestRuleTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/AbstractWebRequestRuleTest.java
@@ -23,8 +23,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Collection;
 
 import static io.microsphere.collection.Lists.ofList;
+import static io.microsphere.collection.Sets.ofSet;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -67,7 +67,7 @@ public class AbstractWebRequestRuleTest {
 
     @Test
     public void testIsEmptyWhenContentIsNotEmpty() {
-        AbstractWebRequestRule<String> rule = createRule(singleton("test"), "||");
+        AbstractWebRequestRule<String> rule = createRule(ofSet("test"), "||");
         assertFalse(rule.isEmpty());
     }
 
@@ -96,19 +96,19 @@ public class AbstractWebRequestRuleTest {
     // equals() ================================
     @Test
     public void testEqualsWithSameInstance() {
-        AbstractWebRequestRule<String> rule = createRule(singleton("a"), "||");
+        AbstractWebRequestRule<String> rule = createRule(ofSet("a"), "||");
         assertTrue(rule.equals(rule));
     }
 
     @Test
     public void testEqualsWithNull() {
-        AbstractWebRequestRule<String> rule = createRule(singleton("a"), "||");
+        AbstractWebRequestRule<String> rule = createRule(ofSet("a"), "||");
         assertFalse(rule.equals(null));
     }
 
     @Test
     public void testEqualsWithDifferentClass() {
-        AbstractWebRequestRule<String> rule = createRule(singleton("a"), "||");
+        AbstractWebRequestRule<String> rule = createRule(ofSet("a"), "||");
         Object other = new Object();
         assertFalse(rule.equals(other));
     }
@@ -137,8 +137,8 @@ public class AbstractWebRequestRuleTest {
 
     @Test
     public void testHashCodeForUnequalObjects() {
-        AbstractWebRequestRule<String> rule1 = createRule(singleton("a"), "||");
-        AbstractWebRequestRule<String> rule2 = createRule(singleton("b"), "||");
+        AbstractWebRequestRule<String> rule1 = createRule(ofSet("a"), "||");
+        AbstractWebRequestRule<String> rule2 = createRule(ofSet("b"), "||");
         assertNotEquals(rule1.hashCode(), rule2.hashCode());
     }
 
@@ -151,7 +151,7 @@ public class AbstractWebRequestRuleTest {
 
     @Test
     public void testToStringWithSingleContent() {
-        AbstractWebRequestRule<String> rule = createRule(singleton("test"), "||");
+        AbstractWebRequestRule<String> rule = createRule(ofSet("test"), "||");
         assertEquals("[test]", rule.toString());
     }
 

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/ProduceMediaTypeExpressionTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/ProduceMediaTypeExpressionTest.java
@@ -23,13 +23,14 @@ import org.springframework.http.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.spring.web.rule.ProduceMediaTypeExpression.parseExpressions;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_XML;
+import static org.springframework.http.MediaType.parseMediaType;
 
 /**
  * {@link ProduceMediaTypeExpression} Test
@@ -40,7 +41,7 @@ public class ProduceMediaTypeExpressionTest {
     @Test
     public void testMatchPositive() {
         ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression("text/plain");
-        List<MediaType> acceptedTypes = singletonList(MediaType.TEXT_PLAIN);
+        List<MediaType> acceptedTypes = ofList(MediaType.TEXT_PLAIN);
         assertTrue(expr.match(acceptedTypes));
     }
 
@@ -48,7 +49,7 @@ public class ProduceMediaTypeExpressionTest {
     @Test
     public void testNegatedExpression() {
         ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression(MediaType.TEXT_PLAIN, true);
-        List<MediaType> acceptedTypes = singletonList(MediaType.TEXT_PLAIN);
+        List<MediaType> acceptedTypes = ofList(MediaType.TEXT_PLAIN);
         assertFalse(expr.match(acceptedTypes));
     }
 
@@ -56,16 +57,16 @@ public class ProduceMediaTypeExpressionTest {
     @Test
     public void testMatchWithParameters() {
         ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression("text/plain;charset=utf-8");
-        MediaType acceptedType = MediaType.parseMediaType("text/plain;charset=UTF-8");
-        assertTrue(expr.match(singletonList(acceptedType)));
+        MediaType acceptedType = parseMediaType("text/plain;charset=UTF-8");
+        assertTrue(expr.match(ofList(acceptedType)));
     }
 
     // Test parameter mismatch
     @Test
     public void testParameterMismatch() {
         ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression("text/plain;version=1");
-        MediaType acceptedType = MediaType.parseMediaType("text/plain;version=2");
-        assertFalse(expr.match(singletonList(acceptedType)));
+        MediaType acceptedType = parseMediaType("text/plain;version=2");
+        assertFalse(expr.match(ofList(acceptedType)));
     }
 
     // Test empty input handling

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/ProduceMediaTypeExpressionTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/rule/ProduceMediaTypeExpressionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
 import static org.springframework.http.MediaType.TEXT_XML;
 import static org.springframework.http.MediaType.parseMediaType;
 
@@ -41,15 +42,15 @@ public class ProduceMediaTypeExpressionTest {
     @Test
     public void testMatchPositive() {
         ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression("text/plain");
-        List<MediaType> acceptedTypes = ofList(MediaType.TEXT_PLAIN);
+        List<MediaType> acceptedTypes = ofList(TEXT_PLAIN);
         assertTrue(expr.match(acceptedTypes));
     }
 
     // Test negation case
     @Test
     public void testNegatedExpression() {
-        ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression(MediaType.TEXT_PLAIN, true);
-        List<MediaType> acceptedTypes = ofList(MediaType.TEXT_PLAIN);
+        ProduceMediaTypeExpression expr = new ProduceMediaTypeExpression(TEXT_PLAIN, true);
+        List<MediaType> acceptedTypes = ofList(TEXT_PLAIN);
         assertFalse(expr.match(acceptedTypes));
     }
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/metadata/HandlerMetadataWebEndpointMappingFactory.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/metadata/HandlerMetadataWebEndpointMappingFactory.java
@@ -30,8 +30,8 @@ import org.springframework.web.reactive.HandlerMapping;
 
 import java.util.Collection;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.web.util.HttpUtils.ALL_HTTP_METHODS;
-import static java.util.Collections.singleton;
 
 /**
  * {@link WebEndpointMappingFactory} based on Spring WebFlux Handlers
@@ -52,6 +52,6 @@ public class HandlerMetadataWebEndpointMappingFactory extends HandlerMappingWebE
 
     @Override
     protected Collection<String> getPatterns(Object handler, String metadata) {
-        return singleton(metadata);
+        return ofSet(metadata);
     }
 }

--- a/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/function/server/RequestPredicateKindTest.java
+++ b/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/function/server/RequestPredicateKindTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static io.microsphere.collection.ListUtils.ofList;
 import static io.microsphere.collection.MapUtils.newHashMap;
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.constants.SymbolConstants.DOT;
 import static io.microsphere.reflect.MethodUtils.findMethod;
 import static io.microsphere.spring.webflux.function.server.RequestPredicateKind.ACCEPT;
@@ -53,7 +54,6 @@ import static io.microsphere.spring.webflux.function.server.RequestPredicateKind
 import static io.microsphere.spring.webflux.test.WebTestUtils.TEST_ROOT_PATH;
 import static io.microsphere.spring.webflux.test.WebTestUtils.mockServerWebExchange;
 import static java.lang.ThreadLocal.withInitial;
-import static java.util.Collections.singleton;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -105,7 +105,7 @@ class RequestPredicateKindTest {
         METHOD.accept(predicate, new RequestPredicateVisitorAdapter() {
             @Override
             public void method(Set<HttpMethod> methods) {
-                assertEquals(singleton(GET), methods);
+                assertEquals(ofSet(GET), methods);
             }
         });
     }

--- a/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/function/server/RequestPredicateVisitorAdapterTest.java
+++ b/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/function/server/RequestPredicateVisitorAdapterTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.server.RequestPredicate;
 
 import java.util.Set;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.reflect.MethodUtils.findMethod;
 import static io.microsphere.spring.webflux.function.server.RequestPredicateKindTest.TEST_PATH_EXTENSION;
 import static io.microsphere.spring.webflux.function.server.RequestPredicateVisitorAdapter.VISITOR_CLASS;
@@ -33,7 +34,6 @@ import static io.microsphere.spring.webflux.test.WebTestUtils.PARAM_VALUE;
 import static io.microsphere.spring.webflux.test.WebTestUtils.TEST_ROOT_PATH;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -195,7 +195,7 @@ class RequestPredicateVisitorAdapterTest {
 
             @Override
             public void method(Set<HttpMethod> methods) {
-                assertEquals(singleton(GET), methods);
+                assertEquals(ofSet(GET), methods);
             }
 
             @Override

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/metadata/HandlerMetadataWebEndpointMappingFactory.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/metadata/HandlerMetadataWebEndpointMappingFactory.java
@@ -21,8 +21,8 @@ import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.Collection;
 
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.web.util.HttpUtils.ALL_HTTP_METHODS;
-import static java.util.Collections.singleton;
 
 /**
  * {@link WebEndpointMappingFactory} based on Spring WebMVC Handlers
@@ -43,6 +43,6 @@ public class HandlerMetadataWebEndpointMappingFactory extends HandlerMappingWebE
 
     @Override
     protected Collection<String> getPatterns(Object handler, String metadata) {
-        return singleton(metadata);
+        return ofSet(metadata);
     }
 }


### PR DESCRIPTION
This pull request refactors usage of singleton collection factories throughout the codebase, replacing calls to `Collections.singleton`, `Collections.singletonList`, and similar methods with custom utility methods (`ofSet`, `ofList`) from the `microsphere.collection` package. Additionally, it modernizes JUnit test assertions by replacing the `@Test(expected=...)` pattern with `assertThrows`, and updates some static imports for consistency. These changes improve code readability, maintainability, and ensure consistent collection handling across the project.

### Refactoring collection creation

* Replaced usages of `Collections.singleton` and `Collections.singletonList` with `ofSet` and `ofList` respectively in both main and test code, ensuring all single-element collections use the custom utility methods for consistency. (`microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/DependencyAnalysisBeanFactoryListener.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtilsTest.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/cache/annotation/EnableTTLCachingTest.java`) [[1]](diffhunk://#diff-0c2b721469dcc3c2477686ea54057610f04177073014f89f3eb9b0f088bc6d0aL234-R234) [[2]](diffhunk://#diff-9d97c387287b9cabceb5c97db5b2cb6eeb29858128cf572129817f89e84efe1aL144-R144) [[3]](diffhunk://#diff-7e07efdb49bea065d772604e26d149971f59cb6c65d81d90beeb60f7bf5e9ef8L278-R278) [[4]](diffhunk://#diff-e0039e2ab02e8cc210d25d8e6618a7d31d87ee999c6cebeea147043cc6066072L300-R300) [[5]](diffhunk://#diff-b6d46c8f36ff86158478a74740b1f0a5c9fa8d28e0dc4888869fe600577ed75fL296-R296) [[6]](diffhunk://#diff-8a80866697fa5ac1c373d416fcc53c4edbccb5716298e3eb65b141a47a17485bL52-R52) [[7]](diffhunk://#diff-8a80866697fa5ac1c373d416fcc53c4edbccb5716298e3eb65b141a47a17485bL61-R61)

### Test modernization

* Updated JUnit tests to use `assertThrows` instead of the deprecated `@Test(expected=...)` annotation, improving clarity and compatibility with modern JUnit versions. (`microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/filter/ResolvableDependencyTypeFilterTest.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionAttributesTest.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/core/MethodParameterUtilsTest.java`) [[1]](diffhunk://#diff-bb3563c1f36f142a7c261e2279a2a5ac1c09e6a5f877ac61f6430360d5991f59L81-R84) [[2]](diffhunk://#diff-27234a4eef09aded98cf1ee68f45c306ce8bdb7d5c4eb9bdfe875c39ccb66847L65-R68) [[3]](diffhunk://#diff-38902f5be9353f73ff465e340fbac6c276df228f69feb8e4d2b6f6e632b215dfL130-R135) [[4]](diffhunk://#diff-89bfd6e6dc5b8d572a0a8914365d7a4fef36a413109c534e54a97ee31f0d9c1cL79-R82)

### Static import and assertion improvements

* Replaced deprecated or less-preferred static imports (such as `org.junit.Assert.assertArrayEquals`) with direct imports, and improved assertion usage for better readability in tests. (`microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java`) [[1]](diffhunk://#diff-7115ec2d40f3b334aa08d05d8aefdc1a3f092e2139e5ada46fc4fbd63bd8850fR36) [[2]](diffhunk://#diff-7115ec2d40f3b334aa08d05d8aefdc1a3f092e2139e5ada46fc4fbd63bd8850fL304-R304)

### Minor cleanup

* Removed unused imports and streamlined import statements in several test files for better maintainability. (`microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/annotation/EnableConfigurationBeanBindingTestForAlias.java`, `microsphere-spring-context/src/test/java/io/microsphere/spring/config/env/annotation/YamlPropertySourceTest.java`) [[1]](diffhunk://#diff-543436462a3b1474ec752eae2eded1d8aad386f76e67189c054285193fcd2418L6-L9) [[2]](diffhunk://#diff-28c47db9d5aeafe72182d1d2dfbcb272905218e1813acbd775bd80138237ba77L29)

### Utility method adoption

* Added new static imports for `ofSet` and `ofList` in files that now use these utility methods, ensuring correct references and reducing risk of errors. (`microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java`, `microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/DependencyAnalysisBeanFactoryListener.java`, [[1]](diffhunk://#diff-b6d46c8f36ff86158478a74740b1f0a5c9fa8d28e0dc4888869fe600577ed75fR36) [[2]](diffhunk://#diff-8a80866697fa5ac1c373d416fcc53c4edbccb5716298e3eb65b141a47a17485bL33-R33) [[3]](diffhunk://#diff-0c2b721469dcc3c2477686ea54057610f04177073014f89f3eb9b0f088bc6d0aR68) [[4]](diffhunk://#diff-9d97c387287b9cabceb5c97db5b2cb6eeb29858128cf572129817f89e84efe1aR40) [[5]](diffhunk://#diff-7e07efdb49bea065d772604e26d149971f59cb6c65d81d90beeb60f7bf5e9ef8R52-L58) [[6]](diffhunk://#diff-e0039e2ab02e8cc210d25d8e6618a7d31d87ee999c6cebeea147043cc6066072R54) [[7]](diffhunk://#diff-b6d46c8f36ff86158478a74740b1f0a5c9fa8d28e0dc4888869fe600577ed75fR36) [[8]](diffhunk://#diff-8a80866697fa5ac1c373d416fcc53c4edbccb5716298e3eb65b141a47a17485bL33-R33)