### PR TITLE
Release 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The easiest way to get started is by adding the Microsphere Spring BOM (Bill of 
 
 | **Branches** | **Purpose**                                    | **Latest Version** |
 |--------------|------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Framework 6.0.x - 6.2.x | 0.2.3              |
-| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.3              |
+| **0.2.x**    | Compatible with Spring Framework 6.0.x - 6.2.x | 0.2.4              |
+| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.4              |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/BeanPropertyChangedEvent.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/BeanPropertyChangedEvent.java
@@ -28,7 +28,7 @@ import java.util.StringJoiner;
  * during runtime.
  * </p>
  *
- * <h3>Example usage:</h3>
+ * <h3>Example Usage</h3>
  * <pre>
  * // Create and publish the event when a bean's property changes
  * BeanPropertyChangedEvent event = new BeanPropertyChangedEvent(myBean, "status", oldStatus, newStatus);

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
@@ -1362,7 +1362,8 @@ public class WebEndpointMapping<E> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WebEndpointMapping that = (WebEndpointMapping) o;
-        return this.negated == that.negated
+        return this.kind == that.kind
+                && this.negated == that.negated
                 && arrayEquals(patterns, that.patterns)
                 && arrayEquals(methods, that.methods)
                 && arrayEquals(params, that.params)
@@ -1418,6 +1419,7 @@ public class WebEndpointMapping<E> {
     public String toJSON() {
         StringBuilder stringBuilder = new StringBuilder(LEFT_CURLY_BRACE).append(LINE_SEPARATOR);
         append(stringBuilder, "id", this.id);
+        append(stringBuilder, "kind", this.kind, COMMA, LINE_SEPARATOR);
         append(stringBuilder, "negated", this.negated, COMMA, LINE_SEPARATOR);
         append(stringBuilder, "patterns", this.patterns, COMMA, LINE_SEPARATOR);
         append(stringBuilder, "methods", this.methods, COMMA, LINE_SEPARATOR);
@@ -1436,6 +1438,11 @@ public class WebEndpointMapping<E> {
     private void append(StringBuilder appendable, String name, boolean value, String... prefixes) {
         append(prefixes, appendable);
         JSONUtils.append(appendable, name, value);
+    }
+
+    private void append(StringBuilder appendable, String name, Kind kind, String... prefixes) {
+        append(prefixes, appendable);
+        JSONUtils.append(appendable, name, kind);
     }
 
     private void append(StringBuilder appendable, String name, String[] values, String... prefixes) {

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
@@ -519,6 +519,9 @@ public class WebEndpointMappingTest {
         assertNotEquals(mapping, null);
         assertNotEquals(mapping, this);
 
+        // equals with different kinds
+        assertNotEquals(mapping, minBuilder(FILTER).build());
+
         // equals with different patterns
         assertNotEquals(mapping, minServletBuilder().pattern("/**").build());
 

--- a/microsphere-spring-web/src/test/resources/META-INF/web-mapping-descriptor.json
+++ b/microsphere-spring-web/src/test/resources/META-INF/web-mapping-descriptor.json
@@ -1,5 +1,6 @@
 {
 "id":1,
+"kind":"CUSTOMIZED",
 "negated":true,
 "patterns":["/a","/b","/c"],
 "methods":["GET","POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <revision>0.1.3-SNAPSHOT</revision>
+        <revision>0.1.4-SNAPSHOT</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request focuses on updating version numbers and enhancing the `WebEndpointMapping` class to improve equality checks and JSON serialization. The most important changes are grouped below:

**Version Updates:**

* Updated the latest versions for the `0.2.x` and `0.1.x` branches in `README.md` to `0.2.4` and `0.1.4` respectively.
* Updated the project revision property in `pom.xml` from `0.1.3-SNAPSHOT` to `0.1.4-SNAPSHOT`.

**Enhancements to `WebEndpointMapping`:**

* Improved the `equals` method in `WebEndpointMapping` to include the `kind` field in equality checks, ensuring more accurate object comparisons.
* Enhanced the `toJSON` method and related helper methods in `WebEndpointMapping` to serialize the `kind` field, and updated the corresponding JSON test resource to include `"kind":"CUSTOMIZED"`. [[1]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aR1422) [[2]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aR1443-R1447) [[3]](diffhunk://#diff-07d14e6fc238889e00ee13eeabef1ab408714557a03b8ff67903962a805ce8aaR3)

**Testing Improvements:**

* Added a test case in `WebEndpointMappingTest` to verify that mappings with different `kind` values are not considered equal.

**Documentation:**

* Corrected minor formatting in the JavaDoc example usage for `BeanPropertyChangedEvent`.