### PR TITLE
Release 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The easiest way to get started is by adding the Microsphere Spring BOM (Bill of 
 
 | **Branches** | **Purpose**                                    | **Latest Version** |
 |--------------|------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Framework 6.0.x - 6.2.x | 0.2.4              |
-| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.4              |
+| **0.2.x**    | Compatible with Spring Framework 6.0.x - 6.2.x | 0.2.5              |
+| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.5              |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/util/MimeTypeUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/util/MimeTypeUtils.java
@@ -23,6 +23,8 @@ import org.springframework.util.MimeType;
 import java.util.Collection;
 
 import static io.microsphere.collection.CollectionUtils.isEmpty;
+import static io.microsphere.util.StringUtils.EMPTY_STRING;
+import static io.microsphere.util.StringUtils.substringAfter;
 
 /**
  * The utility class for MIME Type
@@ -101,11 +103,8 @@ public abstract class MimeTypeUtils implements Utils {
             return null;
         }
         String subtype = one.getSubtype();
-        int suffixIndex = subtype.lastIndexOf('+');
-        if (suffixIndex != -1 && subtype.length() > suffixIndex) {
-            return subtype.substring(suffixIndex + 1);
-        }
-        return null;
+        String suffix = substringAfter(subtype, "+");
+        return EMPTY_STRING.equals(suffix) ? null : suffix;
     }
 
     private MimeTypeUtils() {

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.1.6</microsphere-java.version>
+        <microsphere-java.version>0.1.7</microsphere-java.version>
         <annotation-api.version>1.3.2</annotation-api.version>
         <servlet-api.version>4.0.1</servlet-api.version>
         <jackson.version>2.18.2</jackson.version>

--- a/microsphere-spring-test/pom.xml
+++ b/microsphere-spring-test/pom.xml
@@ -128,38 +128,45 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-tribes</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina-ha</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Apache Zookeeper -->
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Apache Curator -->
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
+            <optional>true</optional>
         </dependency>
 
     </dependencies>

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
@@ -59,6 +59,7 @@ import static io.microsphere.util.StringUtils.EMPTY_STRING_ARRAY;
 import static java.util.function.Function.identity;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpMethod.values;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
@@ -243,7 +244,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For aServletendpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.endpoint("myServlet");
          *
@@ -267,7 +268,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.pattern("/api/users");
          *
@@ -296,7 +297,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of pattern strings
+         * // For a Servlet endpoint with a list of pattern strings
          * List<String> patternList = Arrays.asList("/api/users", "/api/orders");
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.patterns(patternList, Function.identity());
@@ -323,7 +324,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.patterns("/api/users", "/api/orders");
          *
@@ -346,7 +347,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.patterns(Arrays.asList("/api/users", "/api/orders"));
          *
@@ -372,7 +373,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.method(HttpMethod.GET);
          *
@@ -396,7 +397,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.method("GET");
          *
@@ -424,7 +425,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of HttpMethod enums
+         * // For a Servlet endpoint with a list of HttpMethod enums
          * List<HttpMethod> methodList = Arrays.asList(HttpMethod.GET, HttpMethod.POST);
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.methods(methodList, HttpMethod::name);
@@ -451,7 +452,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.methods(HttpMethod.GET, HttpMethod.POST);
          *
@@ -476,7 +477,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.methods("GET", "POST");
          *
@@ -506,7 +507,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.param("version", "v1");
          *
@@ -531,7 +532,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.param("version=v1");
          *
@@ -558,7 +559,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of parameter objects
+         * // For a Servlet endpoint with a list of parameter objects
          * List<MyParam> paramList = Arrays.asList(new MyParam("version", "v1"), new MyParam("lang", "en"));
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.params(paramList, p -> p.getName() + "=" + p.getValue());
@@ -585,7 +586,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.params("version=v1", "lang=en");
          *
@@ -610,7 +611,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.header("X-API-Version", "v1");
          *
@@ -640,7 +641,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.header("X-API-Version:v1");
          *
@@ -668,7 +669,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of header objects
+         * // For a Servlet endpoint with a list of header objects
          * List<MyHeader> headerList = Arrays.asList(new MyHeader("X-API-Version", "v1"), new MyHeader("Accept-Language", "en"));
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.headers(headerList, h -> h.getName() + ":" + h.getValue());
@@ -695,7 +696,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.headers("X-API-Version:v1", "Accept-Language:en");
          *
@@ -720,7 +721,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.consume(MediaType.APPLICATION_JSON);
          *
@@ -744,7 +745,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.consume("application/json");
          *
@@ -772,7 +773,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.consumes(MediaType.APPLICATION_JSON, MediaType.TEXT_XML);
          *
@@ -795,7 +796,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of MediaType objects
+         * // For a Servlet endpoint with a list of MediaType objects
          * List<MediaType> mediaTypeList = Arrays.asList(MediaType.APPLICATION_JSON, MediaType.TEXT_XML);
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.consumes(mediaTypeList, MediaType::toString);
@@ -822,7 +823,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.consumes("application/json", "text/xml");
          *
@@ -847,7 +848,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.produce(MediaType.APPLICATION_JSON);
          *
@@ -871,7 +872,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.produce("application/json");
          *
@@ -899,7 +900,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.produces(MediaType.APPLICATION_JSON, MediaType.TEXT_XML);
          *
@@ -924,7 +925,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint with a list of MediaType objects
+         * // For a Servlet endpoint with a list of MediaType objects
          * List<MediaType> mediaTypeList = Arrays.asList(MediaType.APPLICATION_JSON, MediaType.TEXT_XML);
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.produces(mediaTypeList, MediaType::toString);
@@ -951,7 +952,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.produces("application/json", "text/xml");
          *
@@ -982,7 +983,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For a servlet endpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.source(servletContext);
          *
@@ -1105,10 +1106,13 @@ public class WebEndpointMapping<E> {
             assertNotNull(this.endpoint, () -> "The 'endpoint' must not be null");
 
             assertNotEmpty(this.patterns, () -> "The 'pattern' must not be empty");
-            assertNoNullElements(this.patterns, "Any element of 'patterns' must not be null");
+            assertNoNullElements(this.patterns, () -> "Any element of 'patterns' must not be null");
 
-            assertNotEmpty(this.methods, () -> "The 'methods' must not be empty");
-            assertNoNullElements(this.methods, "Any element of 'methods' must not be null");
+            if (isEmpty(this.methods)) {
+                methods(values());
+            }
+
+            assertNoNullElements(this.methods, () -> "Any element of 'methods' must not be null");
 
             return new WebEndpointMapping(
                     this.kind,

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/WebEndpointMappingTest.java
@@ -33,6 +33,7 @@ import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.io.IOUtils.copyToString;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Builder.assertBuilders;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Builder.pair;
+import static io.microsphere.spring.web.metadata.WebEndpointMapping.Builder.toStrings;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Kind.CUSTOMIZED;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Kind.FILTER;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Kind.SERVLET;
@@ -62,6 +63,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.values;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_XML;
@@ -123,7 +125,8 @@ public class WebEndpointMappingTest {
 
     @Test
     public void testBuildWithoutMethods() {
-        assertThrows(IllegalArgumentException.class, servlet().endpoint(this).patterns(TEST_URL_PATTERNS)::build);
+        WebEndpointMapping mapping = servlet().endpoint(this).patterns(TEST_URL_PATTERNS).build();
+        assertArrayEquals(toStrings(values(), HttpMethod::name), mapping.getMethods());
     }
 
     @Test

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/context/request/ServerWebRequest.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/context/request/ServerWebRequest.java
@@ -40,8 +40,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import static io.microsphere.collection.MapUtils.newFixedLinkedHashMap;
+import static io.microsphere.collection.SetUtils.newHashSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.web.util.MonoUtils.getValue;
 import static io.microsphere.util.ClassUtils.isAssignableFrom;
@@ -160,7 +162,9 @@ public class ServerWebRequest implements NativeWebRequest {
     @Nonnull
     public Iterator<String> getHeaderNames() {
         HttpHeaders httpHeaders = getRequestHeaders();
-        return httpHeaders.keySet().iterator();
+        Set<String> keys = newHashSet(httpHeaders.size());
+        httpHeaders.forEach((key, values) -> keys.add(key));
+        return keys.iterator();
     }
 
     @Override

--- a/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/handler/ReversedProxyHandlerMappingTest.java
+++ b/microsphere-spring-webflux/src/test/java/io/microsphere/spring/webflux/handler/ReversedProxyHandlerMappingTest.java
@@ -38,7 +38,6 @@ import static io.microsphere.spring.web.metadata.WebEndpointMapping.ID_HEADER_NA
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.servlet;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.webflux;
 import static java.lang.String.valueOf;
-import static java.lang.System.currentTimeMillis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -115,7 +114,7 @@ class ReversedProxyHandlerMappingTest extends AbstractWebFluxTest {
     protected void testResponseEntity() {
         this.webTestClient.put()
                 .uri("/test/response-entity")
-                .header(ID_HEADER_NAME, valueOf(currentTimeMillis()))
+                .header(ID_HEADER_NAME, "1")
                 .exchange()
                 .expectBody(String.class)
                 .isEqualTo("OK");

--- a/microsphere-spring-webmvc/pom.xml
+++ b/microsphere-spring-webmvc/pom.xml
@@ -97,6 +97,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Apache Tomcat -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- JSON Assert -->
         <dependency>
             <groupId>org.skyscreamer</groupId>

--- a/microsphere-spring-webmvc/src/test/java/io/microsphere/spring/webmvc/handler/ReversedProxyHandlerMappingTest.java
+++ b/microsphere-spring-webmvc/src/test/java/io/microsphere/spring/webmvc/handler/ReversedProxyHandlerMappingTest.java
@@ -122,7 +122,7 @@ public class ReversedProxyHandlerMappingTest extends AbstractWebMvcTest {
     @Test
     public void testResponseEntity() throws Exception {
         String pattern = "/test/response-entity";
-        this.mockMvc.perform(put(pattern).header(ID_HEADER_NAME, currentTimeMillis()))
+        this.mockMvc.perform(put(pattern).header(ID_HEADER_NAME, "1"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("OK"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <revision>0.1.4-SNAPSHOT</revision>
+        <revision>0.1.5-SNAPSHOT</revision>
     </properties>
 
     <modules>
@@ -67,29 +67,5 @@
         <module>microsphere-spring-guice</module>
         <module>microsphere-spring-test</module>
     </modules>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
-    <repositories>
-        <repository>
-            <id>snapshot</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
 
 </project>


### PR DESCRIPTION
This pull request introduces a few minor improvements and dependency updates across the codebase. The most notable changes are an update to the `getSubtypeSuffix` utility logic, marking several test dependencies as optional, updating version numbers, and improving documentation consistency.

Dependency and version updates:

* Updated the `microsphere-java.version` property in `microsphere-spring-parent/pom.xml` from `0.1.6` to `0.1.7`.
* Marked several dependencies as optional in `microsphere-spring-test/pom.xml` to reduce unnecessary transitive dependencies in downstream projects.
* Updated the latest version numbers for the 0.2.x and 0.1.x branches in `README.md`.

Utility and code improvements:

* Refactored `MimeTypeUtils.getSubtypeSuffix` to use `substringAfter` and `EMPTY_STRING` for improved clarity and null handling, and added related imports. [[1]](diffhunk://#diff-912ce43d882ea6efec96a8ce0564640dbede5b3f1e595d74b6263399f4320f3eR26-R27) [[2]](diffhunk://#diff-912ce43d882ea6efec96a8ce0564640dbede5b3f1e595d74b6263399f4320f3eL104-R107)

Documentation consistency:

* Standardized Javadoc example comments in `WebEndpointMapping.java` to use "Servlet endpoint" instead of "servlet endpoint" for consistency and clarity. [[1]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL246-R247) [[2]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL270-R271) [[3]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL299-R300) [[4]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL326-R327) [[5]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL349-R350) [[6]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL375-R376) [[7]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL399-R400) [[8]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL427-R428) [[9]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL454-R455) [[10]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL479-R480) [[11]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL509-R510) [[12]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL534-R535) [[13]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL561-R562) [[14]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL588-R589) [[15]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL613-R614) [[16]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL643-R644) [[17]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL671-R672) [[18]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL698-R699) [[19]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL723-R724) [[20]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL747-R748) [[21]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL775-R776) [[22]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL798-R799) [[23]](diffhunk://#diff-fccf485e157f10701bf806576a46213f4ee56944053d3f50f1443c994de4bc8aL825-R826)

These changes help improve code clarity, maintainability, and reduce unnecessary dependencies for consumers.