### PR TITLE
Fix typo in JavaDoc example usage comment

### DIFF
--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/WebEndpointMapping.java
@@ -244,7 +244,7 @@ public class WebEndpointMapping<E> {
          *
          * <h3>Example Usage</h3>
          * <pre>{@code
-         * // For aServletendpoint
+         * // For a Servlet endpoint
          * WebEndpointMapping.Builder<String> builder = WebEndpointMapping.servlet("myServlet");
          * builder.endpoint("myServlet");
          *


### PR DESCRIPTION
Corrected 'aServletendpoint' to 'a Servlet endpoint' in the JavaDoc example usage comment for better readability.