### PR TITLE
Update Microsphere versions and expand Java CI matrix

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        java: [ '8' , '11' ]
+        java: [ '8' , '11' , '17' , '21' , '25' ]
         maven-profile-spring-framework: [
           'spring-framework-5.3' , 'spring-framework-5.2', 'spring-framework-5.1' , 'spring-framework-5.0' ,
           'spring-framework-4.3'

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,8 +20,8 @@
 
     <properties>
         <microsphere-bom.version>0.2.1</microsphere-bom.version>
-        <microsphere-java.version>0.3.0</microsphere-java.version>
-        <microsphere-logging.version>0.1.8</microsphere-logging.version>
+        <microsphere-java.version>0.3.1</microsphere-java.version>
+        <microsphere-logging.version>0.1.9</microsphere-logging.version>
         <jackson.version>2.21.2</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>
@@ -32,15 +32,6 @@
 
     <dependencyManagement>
         <dependencies>
-
-            <!-- Microsphere BOMs -->
-            <dependency>
-                <groupId>io.github.microsphere-projects</groupId>
-                <artifactId>microsphere-javadb-bom</artifactId>
-                <version>${microsphere-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <!-- Jackson BOM -->
             <dependency>
@@ -63,6 +54,13 @@
                 <groupId>p6spy</groupId>
                 <artifactId>p6spy</artifactId>
                 <version>${p6spy.version}</version>
+            </dependency>
+
+            <!-- Apache Tomcat -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
             </dependency>
 
             <!-- Apache Zookeeper -->
@@ -131,13 +129,6 @@
                 <version>${microsphere-logging.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- Apache Tomcat -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
             </dependency>
             
         </dependencies>


### PR DESCRIPTION
This pull request updates the Java build matrix, upgrades dependencies, and reorganizes how the Apache Tomcat dependency is managed in the Maven configuration. The most important changes are as follows:

**Build Matrix Updates:**

* Expanded the Java versions tested in the GitHub Actions workflow (`.github/workflows/maven-build.yml`) to include Java 17, 21, and 25, in addition to 8 and 11.

**Dependency Upgrades:**

* Upgraded `microsphere-java` from version 0.3.0 to 0.3.1 and `microsphere-logging` from 0.1.8 to 0.1.9 in `microsphere-spring-parent/pom.xml`.

**Dependency Management Restructuring:**

* Removed the import of the `microsphere-javadb-bom` from the dependency management section in `microsphere-spring-parent/pom.xml`.
* Moved the `tomcat-embed-core` dependency from the dependency management section to the main dependencies list in `microsphere-spring-parent/pom.xml`. [[1]](diffhunk://#diff-4ca817205f281a3f55a1b174dc8821b0b2500e0c597d4fea19b6072826228417R59-R65) [[2]](diffhunk://#diff-4ca817205f281a3f55a1b174dc8821b0b2500e0c597d4fea19b6072826228417L136-L142)