### PR TITLE
Standardize Maven workflows and update dependencies

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v5
 
-      - name: Setup JDK ${{ matrix.Java }}
+      - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -21,7 +21,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
       matrix:
         java: [ '8' , '11' , '17' , '21' , '25' ]
         maven-profile-spring-framework: [

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -28,6 +28,7 @@ jobs:
           'spring-framework-5.3' , 'spring-framework-5.2', 'spring-framework-5.1' , 'spring-framework-5.0' ,
           'spring-framework-4.3'
         ]
+
     steps:
       - name: Checkout Source
         uses: actions/checkout@v5
@@ -37,14 +38,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Build with Maven
-        run: ./mvnw
+        run: mvn
           --batch-mode
           --update-snapshots
           --file pom.xml
           -Drevision=0.0.1-SNAPSHOT
-          -Dsurefire.useSystemClassLoader=false
           test
           --activate-profiles test,coverage,${{ matrix.maven-profile-spring-framework }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,13 +40,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          cache: maven
 
       - name: Publish package
-        run: mvn
+        run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - name: Publish package
         run: ./mvnw

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The easiest way to get started is by adding the Microsphere Spring BOM (Bill of 
 
 | **Branches** | **Purpose**                                    | **Latest Version** |
 |--------------|------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Framework 6.0.x - 7.0.x | 0.2.15             |      
-| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.15             |
+| **0.2.x**    | Compatible with Spring Framework 6.0.x - 7.0.x | 0.2.16             |      
+| **0.1.x**    | Compatible with Spring Framework 4.3.x - 5.3.x | 0.1.16             |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.2</microsphere-java.version>
-        <microsphere-logging.version>0.1.9</microsphere-logging.version>
+        <microsphere-logging.version>0.1.10</microsphere-logging.version>
         <jackson.version>2.21.2</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,8 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-bom.version>0.2.1</microsphere-bom.version>
-        <microsphere-java.version>0.3.1</microsphere-java.version>
+        <microsphere-java.version>0.3.2</microsphere-java.version>
         <microsphere-logging.version>0.1.9</microsphere-logging.version>
         <jackson.version>2.21.2</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.7</version>
+        <version>0.2.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates build and dependency configurations, improves CI workflow efficiency, and bumps project and documentation versions. The main focus is on keeping dependencies up to date, optimizing CI, and ensuring the documentation reflects the latest versions.

**Build and CI workflow improvements:**

* In `.github/workflows/maven-build.yml`, the Maven build step now uses the Maven cache for faster builds and switches from `./mvnw` to the system `mvn` command. The JDK setup step is renamed for clarity, and an unnecessary `max-parallel` setting is removed.
* In `.github/workflows/maven-publish.yml`, the Maven cache is removed from the publish job, and the publish step switches from `mvn` to `./mvnw` for better environment consistency.

**Dependency and version updates:**

* In `microsphere-spring-parent/pom.xml`, dependencies are updated: `microsphere-java.version` to `0.3.2` and `microsphere-logging.version` to `0.1.10`.
* In `pom.xml`, the parent project version is bumped from `0.2.7` to `0.2.9`.

**Documentation updates:**

* In `README.md`, the latest versions for the `0.2.x` and `0.1.x` branches are updated to `0.2.16` and `0.1.16`, respectively.