### PR TITLE
Bump README listed versions to 0.2.20 and 0.1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.19         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.19         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.20         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.20         |
 
 ### 2. Add individual modules
 


### PR DESCRIPTION
Update the README compatibility table to reflect the new latest releases for each branch: `main` updated to 0.2.20 and `1.x` updated to 0.1.20.