### PR TITLE
Enhance bean registration and factory loading utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.20         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.20         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.21         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.21         |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
@@ -17,11 +17,18 @@
 
 package io.microsphere.spring.beans;
 
+import io.microsphere.annotation.Immutable;
+import io.microsphere.annotation.Nonnull;
+import io.microsphere.spring.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
 import java.util.ServiceLoader;
+import java.util.Set;
+
+import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryClasses;
+import static io.microsphere.util.ServiceLoaderUtils.getServiceClasses;
 
 /**
  * The enumeration of Bean Sources
@@ -40,7 +47,12 @@ public enum BeanSource {
      * @see BeanFactory
      * @see ConfigurableListableBeanFactory
      */
-    BEAN_FACTORY,
+    BEAN_FACTORY {
+        @Override
+        public <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType) {
+            return BeanFactoryUtils.getBeanTypes(beanFactory, beanType, true, false);
+        }
+    },
 
     /**
      * Bean from {@link SpringFactoriesLoader Spring Factories},
@@ -48,7 +60,12 @@ public enum BeanSource {
      *
      * @see SpringFactoriesLoader
      */
-    SPRING_FACTORIES,
+    SPRING_FACTORIES {
+        @Override
+        public <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType) {
+            return loadFactoryClasses(beanType, beanFactory.getBeanClassLoader());
+        }
+    },
 
     /**
      * Bean from {@link ServiceLoader Java Service Provider},
@@ -56,5 +73,22 @@ public enum BeanSource {
      *
      * @see ServiceLoader
      */
-    JAVA_SERVICE_PROVIDER
+    JAVA_SERVICE_PROVIDER {
+        @Override
+        public <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType) {
+            return getServiceClasses(beanType, beanFactory.getBeanClassLoader());
+        }
+    };
+
+    /**
+     * Get the all bean types from the current {@link BeanSource} by given base bean type
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory}
+     * @param beanType    the bean type
+     * @return the all bean types from the current {@link BeanSource} by given base
+     */
+    @Nonnull
+    @Immutable
+    public abstract <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType);
+
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
@@ -164,4 +164,34 @@ public enum BeanSource {
                                         Set<Class<?>> beanClasses) {
         return registerGenericBeans(registry, beanClasses);
     }
+
+    /**
+     * Registers beans into the given {@link ConfigurableListableBeanFactory} from the specified {@link BeanSource}s.
+     * <p>
+     * This method iterates over the provided {@code beanSources}, retrieves the bean classes for each {@code beanType}
+     * from each source, and registers them as generic beans. If multiple sources provide beans for the same type,
+     * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
+     * may override earlier ones if the bean name conflicts).
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to register beans into
+     * @param beanSources the array of {@link BeanSource}s to use for discovering bean classes
+     * @param beanTypes   the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @throws IllegalArgumentException if {@code beanSources} is {@code null} or empty
+     * @see #registerBeans(ConfigurableListableBeanFactory, Class...)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    @Nonnull
+    @Immutable
+    public static Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanSource[] beanSources, Class<?>... beanTypes) {
+        int length = length(beanTypes);
+        if (length == 0) {
+            return emptyMap();
+        }
+        Map<Class<?>, String> beanTypesAndNames = newHashMap(length);
+        for (BeanSource beanSource : beanSources) {
+            beanTypesAndNames.putAll(beanSource.registerBeans(beanFactory, beanTypes));
+        }
+        return unmodifiableMap(beanTypesAndNames);
+    }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
@@ -20,15 +20,27 @@ package io.microsphere.spring.beans;
 import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.spring.beans.factory.BeanFactoryUtils;
+import io.microsphere.spring.beans.factory.support.BeanRegistrar;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import static io.microsphere.collection.MapUtils.newHashMap;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanClass;
+import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerGenericBeans;
 import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryClasses;
+import static io.microsphere.util.ArrayUtils.length;
+import static io.microsphere.util.ObjectUtils.defaultIfNull;
 import static io.microsphere.util.ServiceLoaderUtils.getServiceClasses;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * The enumeration of Bean Sources
@@ -51,6 +63,22 @@ public enum BeanSource {
         @Override
         public <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType) {
             return BeanFactoryUtils.getBeanTypes(beanFactory, beanType, true, false);
+        }
+
+        @Override
+        Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                            Set<Class<?>> beanClasses) {
+            // Only to query, do not register, since the beans are already defined in Bean Factory
+            Map<Class<?>, String> beanTypesAndNames = newHashMap(beanClasses.size());
+            for (Class<?> beanClass : beanClasses) {
+                String[] beanNames = beanFactory.getBeanNamesForType(beanClass, true, false);
+                for (String beanName : beanNames) {
+                    Class<?> beanType = getBeanClass(beanFactory, beanName);
+                    beanType = defaultIfNull(beanType, beanClass);
+                    beanTypesAndNames.put(beanType, beanName);
+                }
+            }
+            return beanTypesAndNames;
         }
     },
 
@@ -81,14 +109,59 @@ public enum BeanSource {
     };
 
     /**
-     * Get the all bean types from the current {@link BeanSource} by given base bean type
+     * Gets the set of bean types that are assignable to the given {@code beanType} from this source.
      *
-     * @param beanFactory the {@link ConfigurableListableBeanFactory}
-     * @param beanType    the bean type
-     * @return the all bean types from the current {@link BeanSource} by given base
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to use for resolution
+     * @param beanType    the target bean type to search for
+     * @param <T>         the type of the bean
+     * @return a {@link Set} of {@link Class} objects representing the bean types found, never {@code null}
      */
     @Nonnull
     @Immutable
     public abstract <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType);
 
+    /**
+     * Registers beans into the given {@link ConfigurableListableBeanFactory} based on the specified {@code beanTypes}.
+     * <p>
+     * For each provided {@code beanType}, this method retrieves the corresponding bean classes from this source
+     * (e.g., Bean Factory, Spring Factories, or Java Service Provider) and registers them as generic beans.
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to register beans into
+     * @param beanTypes   the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @see #getBeanTypes(ConfigurableListableBeanFactory, Class)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    @Nonnull
+    @Immutable
+    public Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, Class<?>... beanTypes) {
+        int length = length(beanTypes);
+        if (length == 0) {
+            return emptyMap();
+        }
+        BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
+        Map<Class<?>, String> beanTypesAndNames = registerBeans(beanFactory, registry, beanTypes, length);
+        return unmodifiableMap(beanTypesAndNames);
+    }
+
+    Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                        Class<?>[] beanTypes, int length) {
+        Map<Class<?>, String> beanTypesAndNames = newHashMap(length * 2);
+        for (int i = 0; i < length; i++) {
+            Class<?> beanType = beanTypes[i];
+            beanTypesAndNames.putAll(registerBean(beanFactory, registry, beanType));
+        }
+        return beanTypesAndNames;
+    }
+
+    Map<Class<?>, String> registerBean(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                       Class<?> beanType) {
+        Set<Class<?>> beanClasses = (Set) getBeanTypes(beanFactory, beanType);
+        return registerBeans(beanFactory, registry, beanClasses);
+    }
+
+    Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                        Set<Class<?>> beanClasses) {
+        return registerGenericBeans(registry, beanClasses);
+    }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
@@ -24,9 +24,11 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.HierarchicalBeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -40,9 +42,11 @@ import static io.microsphere.collection.ListUtils.first;
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.collection.SetUtils.newFixedHashSet;
 import static io.microsphere.reflect.FieldUtils.getFieldValue;
+import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.resolveBeanType;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static io.microsphere.util.ArrayUtils.size;
 import static io.microsphere.util.ClassLoaderUtils.nullSafeClassLoader;
+import static io.microsphere.util.ClassUtils.getType;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
@@ -681,6 +685,82 @@ public abstract class BeanFactoryUtils implements Utils {
             beanTypes.add((Class<T>) actualBeanType);
         }
         return unmodifiableSet(beanTypes);
+    }
+
+
+    /**
+     * Retrieves the actual {@link Class} of the bean with the specified name from the given {@link ConfigurableListableBeanFactory}.
+     *
+     * <p>
+     * This method first attempts to retrieve the {@link BeanDefinition} for the specified bean name. If a bean definition
+     * is found, it resolves the bean type from the definition. If no bean definition is available (e.g., for manually
+     * registered singletons), it retrieves the singleton instance and determines its class. If the singleton instance
+     * is also not found, this method returns {@code null}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * ConfigurableListableBeanFactory beanFactory = ...; // Obtain or inject the bean factory
+     * String beanName = "myBean";
+     *
+     * Class<?> beanClass = BeanFactoryUtils.getBeanClass(beanFactory, beanName);
+     *
+     * if (beanClass != null) {
+     *     System.out.println("Bean class: " + beanClass.getName());
+     * } else {
+     *     System.out.println("Could not determine bean class for: " + beanName);
+     * }
+     * }</pre>
+     *
+     * @param beanFactory The target bean factory to retrieve the bean class from. Must not be {@code null}.
+     * @param beanName    The name of the bean whose class is to be retrieved. Must not be {@code null} or empty.
+     * @return The actual {@link Class} of the bean if determinable; otherwise, {@code null}.
+     */
+    @Nullable
+    public static Class<?> getBeanClass(ConfigurableListableBeanFactory beanFactory, String beanName) {
+        BeanDefinition beanDefinition = getBeanDefinition(beanFactory, beanName);
+        if (beanDefinition instanceof AbstractBeanDefinition) {
+            return resolveBeanType((AbstractBeanDefinition) beanDefinition);
+        }
+        // try to find the singleton bean if present
+        Object singleton = beanFactory.getSingleton(beanName);
+        return getType(singleton);
+    }
+
+    /**
+     * Retrieves the {@link BeanDefinition} for the specified bean name from the given {@link ConfigurableListableBeanFactory}.
+     *
+     * <p>
+     * This method checks if the bean factory contains a bean definition for the provided name. If it does,
+     * the corresponding {@link BeanDefinition} is returned. Otherwise, this method returns {@code null}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * ConfigurableListableBeanFactory beanFactory = ...; // Obtain or inject the bean factory
+     * String beanName = "myBean";
+     *
+     * BeanDefinition beanDefinition = BeanFactoryUtils.getBeanDefinition(beanFactory, beanName);
+     *
+     * if (beanDefinition != null) {
+     *     // Inspect or modify the bean definition
+     *     System.out.println("Bean class: " + beanDefinition.getBeanClassName());
+     * } else {
+     *     // Handle case where bean definition is not found
+     *     System.out.println("No bean definition found for name: " + beanName);
+     * }
+     * }</pre>
+     *
+     * @param beanFactory The target bean factory to retrieve the bean definition from. Must not be {@code null}.
+     * @param beanName    The name of the bean whose definition is to be retrieved. Must not be {@code null} or empty.
+     * @return The {@link BeanDefinition} if present in the bean factory; otherwise, {@code null}.
+     */
+    @Nullable
+    public static BeanDefinition getBeanDefinition(ConfigurableListableBeanFactory beanFactory, String beanName) {
+        if (beanFactory.containsBeanDefinition(beanName)) {
+            return beanFactory.getBeanDefinition(beanName);
+        }
+        return null;
     }
 
     private static <T> T cast(@Nullable Object beanFactory, Class<T> extendedBeanFactoryType) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.beans.factory;
 
+import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.annotation.Nullable;
 import io.microsphere.util.Utils;
@@ -37,6 +38,7 @@ import java.util.Set;
 
 import static io.microsphere.collection.ListUtils.first;
 import static io.microsphere.collection.ListUtils.newArrayList;
+import static io.microsphere.collection.SetUtils.newFixedHashSet;
 import static io.microsphere.reflect.FieldUtils.getFieldValue;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static io.microsphere.util.ArrayUtils.size;
@@ -44,6 +46,7 @@ import static io.microsphere.util.ClassLoaderUtils.nullSafeClassLoader;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static org.springframework.beans.factory.BeanFactoryUtils.beanNamesForTypeIncludingAncestors;
 import static org.springframework.util.Assert.isInstanceOf;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -595,6 +598,89 @@ public abstract class BeanFactoryUtils implements Utils {
     public static ClassLoader nullSafeBeanClassLoader(@Nullable BeanFactory beanFactory) {
         ClassLoader classLoader = getBeanClassLoader(beanFactory);
         return nullSafeClassLoader(classLoader);
+    }
+
+    /**
+     * Retrieves the set of bean types that match the specified type from the given {@link ListableBeanFactory}.
+     *
+     * <p>
+     * This method scans the bean factory for beans of the specified type and returns their actual runtime classes.
+     * By default, it includes non-singleton beans and allows eager initialization of FactoryBeans during the search.
+     * The returned set is unmodifiable and immutable.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * ListableBeanFactory beanFactory = ...; // Obtain or inject the bean factory
+     * Class<MyService> serviceType = MyService.class;
+     *
+     * Set<Class<MyService>> serviceTypes = BeanFactoryUtils.getBeanTypes(beanFactory, serviceType);
+     *
+     * if (!serviceTypes.isEmpty()) {
+     *     for (Class<MyService> type : serviceTypes) {
+     *         System.out.println("Found bean type: " + type.getName());
+     *     }
+     * } else {
+     *     System.out.println("No beans of type MyService found.");
+     * }
+     * }</pre>
+     *
+     * @param <T>         The type of the beans to retrieve.
+     * @param beanFactory The target bean factory to search. Must not be {@code null}.
+     * @param beanType    The type to match against. Must not be {@code null}.
+     * @return A non-null, unmodifiable set of actual bean classes matching the specified type. Returns an empty set if no matches are found.
+     */
+    @Nonnull
+    @Immutable
+    public static <T> Set<Class<T>> getBeanTypes(ListableBeanFactory beanFactory, Class<T> beanType) {
+        return getBeanTypes(beanFactory, beanType, true, true);
+    }
+
+    /**
+     * Retrieves the set of bean types that match the specified type from the given {@link ListableBeanFactory}.
+     *
+     * <p>
+     * This method scans the bean factory for beans of the specified type and returns their actual runtime classes.
+     * It allows control over whether to include non-singleton beans and whether to allow eager initialization
+     * of FactoryBeans during the search. The returned set is unmodifiable and immutable.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * ListableBeanFactory beanFactory = ...; // Obtain or inject the bean factory
+     * Class<MyService> serviceType = MyService.class;
+     *
+     * Set<Class<MyService>> serviceTypes = BeanFactoryUtils.getBeanTypes(beanFactory, serviceType, true, false);
+     *
+     * if (!serviceTypes.isEmpty()) {
+     *     for (Class<MyService> type : serviceTypes) {
+     *         System.out.println("Found bean type: " + type.getName());
+     *     }
+     * } else {
+     *     System.out.println("No beans of type MyService found.");
+     * }
+     * }</pre>
+     *
+     * @param <T>                  The type of the beans to retrieve.
+     * @param beanFactory          The target bean factory to search. Must not be {@code null}.
+     * @param beanType             The type to match against. Must not be {@code null}.
+     * @param includeNonSingletons Whether to include prototype-scoped (non-singleton) beans in the search.
+     * @param allowEagerInit       Whether to allow eager initialization of FactoryBeans during the search.
+     * @return A non-null, unmodifiable set of actual bean classes matching the specified type. Returns an empty set if no matches are found.
+     */
+    @Nonnull
+    @Immutable
+    public static <T> Set<Class<T>> getBeanTypes(ListableBeanFactory beanFactory, Class<T> beanType,
+                                                 boolean includeNonSingletons, boolean allowEagerInit) {
+        String[] beanNames = beanFactory.getBeanNamesForType(beanType, includeNonSingletons, allowEagerInit);
+        int beansCount = beanNames.length;
+        Set<Class<T>> beanTypes = newFixedHashSet(beansCount);
+        for (int i = 0; i < beansCount; i++) {
+            String beanName = beanNames[i];
+            Class<?> actualBeanType = beanFactory.getType(beanName);
+            beanTypes.add((Class<T>) actualBeanType);
+        }
+        return unmodifiableSet(beanTypes);
     }
 
     private static <T> T cast(@Nullable Object beanFactory, Class<T> extendedBeanFactoryType) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtils.java
@@ -243,7 +243,7 @@ public abstract class BeanDefinitionUtils implements Utils {
     }
 
     /**
-     * Resolves the bean type from the given {@link RootBeanDefinition} using the default class loader.
+     * Resolves the bean type from the given {@link AbstractBeanDefinition} using the default class loader.
      *
      * <p>This method attempts to resolve the bean type via its {@link ResolvableType}. If that fails,
      * it falls back to resolving the bean class using the bean's class name and the default class loader.
@@ -254,7 +254,7 @@ public abstract class BeanDefinitionUtils implements Utils {
      * Class<?> beanType = resolveBeanType(beanDefinition);
      * }</pre>
      *
-     * @param beanDefinition the {@link RootBeanDefinition} to resolve the bean type from
+     * @param beanDefinition the {@link AbstractBeanDefinition} to resolve the bean type from
      * @return the resolved bean class, or {@code null} if it cannot be resolved
      */
     @Nullable

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/config/BeanDefinitionUtils.java
@@ -258,7 +258,7 @@ public abstract class BeanDefinitionUtils implements Utils {
      * @return the resolved bean class, or {@code null} if it cannot be resolved
      */
     @Nullable
-    public static Class<?> resolveBeanType(RootBeanDefinition beanDefinition) {
+    public static Class<?> resolveBeanType(AbstractBeanDefinition beanDefinition) {
         return resolveBeanType(beanDefinition, getDefaultClassLoader());
     }
 
@@ -288,7 +288,7 @@ public abstract class BeanDefinitionUtils implements Utils {
      * @return the resolved bean class, or {@code null} if it cannot be resolved
      */
     @Nullable
-    public static Class<?> resolveBeanType(RootBeanDefinition beanDefinition, @Nullable ClassLoader classLoader) {
+    public static Class<?> resolveBeanType(AbstractBeanDefinition beanDefinition, @Nullable ClassLoader classLoader) {
         ResolvableType resolvableType = getResolvableType(beanDefinition);
         Class<?> beanClass = resolvableType.resolve();
         if (beanClass == null) { // resolving the bean class as fallback

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
@@ -18,7 +18,6 @@ package io.microsphere.spring.beans.factory.support;
 
 import io.microsphere.annotation.Nullable;
 import io.microsphere.logging.Logger;
-import io.microsphere.spring.beans.BeanUtils;
 import io.microsphere.spring.beans.factory.DelegatingFactoryBean;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.BeanFactory;
@@ -34,7 +33,6 @@ import org.springframework.core.io.support.SpringFactoriesLoader;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
@@ -16,34 +16,46 @@
  */
 package io.microsphere.spring.beans.factory.support;
 
+import io.microsphere.annotation.Nullable;
 import io.microsphere.logging.Logger;
 import io.microsphere.spring.beans.BeanUtils;
 import io.microsphere.spring.beans.factory.DelegatingFactoryBean;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.core.AliasRegistry;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Consumer;
 
+import static io.microsphere.collection.MapUtils.immutableEntry;
+import static io.microsphere.collection.MapUtils.newFixedHashMap;
 import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.genericBeanDefinition;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.setInstanceSupplier;
+import static io.microsphere.spring.beans.factory.support.GenericBeanNameGenerator.INSTANCE;
+import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryClasses;
+import static io.microsphere.util.ArrayUtils.EMPTY_CLASS_ARRAY;
+import static io.microsphere.util.ArrayUtils.length;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.springframework.aop.support.AopUtils.getTargetClass;
 import static org.springframework.beans.factory.config.BeanDefinition.ROLE_INFRASTRUCTURE;
 import static org.springframework.beans.factory.support.BeanDefinitionReaderUtils.generateBeanName;
-import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactoryNames;
-import static org.springframework.util.ClassUtils.resolveClassName;
 import static org.springframework.util.ObjectUtils.containsElement;
 import static org.springframework.util.StringUtils.hasText;
 
@@ -102,19 +114,20 @@ public abstract class BeanRegistrar {
     private static final Logger logger = getLogger(BeanRegistrar.class);
 
     /**
-     * Registers an infrastructure bean of the specified type into the given registry.
+     * Registers an infrastructure bean with the specified type into the given registry.
      * <p>
-     * This method generates a unique bean name based on the bean definition and registers it as an infrastructure bean.
-     * If the bean definition is successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * This method delegates to {@link #registerInfrastructureBean(BeanDefinitionRegistry, String, Class)}
+     * with a {@code null} bean name, causing a unique bean name to be generated automatically.
+     * The registered bean definition will have its role set to {@link BeanDefinition#ROLE_INFRASTRUCTURE}.
      * </p>
      *
      * <h3>Example Usage</h3>
      * <pre>{@code
-     * boolean registered = registerInfrastructureBean(registry, MyInfrastructureClass.class);
+     * boolean registered = registerInfrastructureBean(registry, MyInfrastructureComponent.class);
      * if (registered) {
-     *     System.out.println("Infrastructure bean registered successfully.");
+     *     logger.info("Infrastructure bean registered successfully with auto-generated name.");
      * } else {
-     *     System.out.println("Infrastructure bean was already registered.");
+     *     logger.warn("Infrastructure bean was already registered.");
      * }
      * }</pre>
      *
@@ -123,37 +136,40 @@ public abstract class BeanRegistrar {
      * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
      */
     public static boolean registerInfrastructureBean(BeanDefinitionRegistry registry, Class<?> beanType) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType, ROLE_INFRASTRUCTURE);
-        String beanName = generateBeanName(beanDefinition, registry);
-        return registerBeanDefinition(registry, beanName, beanDefinition);
+        return registerInfrastructureBean(registry, null, beanType);
     }
 
     /**
-     * Registers an infrastructure bean with the specified name and type into the given registry.
+     * Registers an infrastructure bean with the specified type and optional name into the given registry.
      * <p>
-     * This method creates a generic bean definition for the provided bean type with the default role,
-     * and attempts to register it under the specified bean name. If the bean is successfully registered,
-     * it returns {@code true}; otherwise, it returns {@code false}.
+     * This method creates a generic bean definition for the provided bean type with the infrastructure role,
+     * uses the provided bean name if present, or generates a unique bean name otherwise. It then attempts to
+     * register the bean definition. If the bean is successfully registered, it returns {@code true}; otherwise,
+     * it returns {@code false}.
      * </p>
      *
      * <h3>Example Usage</h3>
      * <pre>{@code
-     * boolean registered = registerInfrastructureBean(registry, "myBean", MyBeanClass.class);
+     * // Register with auto-generated name
+     * boolean registered = registerInfrastructureBean(registry, null, MyInfrastructureComponent.class);
+     *
+     * // Register with explicit name
+     * boolean registered = registerInfrastructureBean(registry, "myInfraBean", MyInfrastructureComponent.class);
+     *
      * if (registered) {
-     *     System.out.println("Bean registered successfully.");
+     *     logger.info("Infrastructure bean registered successfully.");
      * } else {
-     *     System.out.println("Bean was already registered.");
+     *     logger.warn("Infrastructure bean was already registered.");
      * }
      * }</pre>
      *
      * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName The name to assign to the bean in the registry.
+     * @param beanName The name to assign to the bean in the registry, or {@code null} to generate a unique name.
      * @param beanType The class type of the bean to be registered.
      * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
      */
-    public static boolean registerInfrastructureBean(BeanDefinitionRegistry registry, String beanName, Class<?> beanType) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType, ROLE_INFRASTRUCTURE);
-        return registerBeanDefinition(registry, beanName, beanDefinition);
+    public static boolean registerInfrastructureBean(BeanDefinitionRegistry registry, @Nullable String beanName, Class<?> beanType) {
+        return registerBeanDefinition(registry, beanName, beanType, ROLE_INFRASTRUCTURE);
     }
 
     /**
@@ -179,182 +195,288 @@ public abstract class BeanRegistrar {
      * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
      */
     public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, Class<?> beanType) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType);
-        String beanName = generateBeanName(beanDefinition, registry);
-        return registerBeanDefinition(registry, beanName, beanDefinition);
+        return registerBeanDefinition(registry, null, beanType);
     }
 
-    /**
-     * Registers a bean definition with the specified name and type into the given registry.
-     * <p>
-     * This method creates a generic bean definition for the provided bean type and attempts to register it
-     * under the specified bean name. If the bean is successfully registered, it returns {@code true};
-     * otherwise, it returns {@code false}.
-     * </p>
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * boolean registered = registerBeanDefinition(registry, "myBean", MyBean.class);
-     * if (registered) {
-     *     logger.info("Bean registered successfully.");
-     * } else {
-     *     logger.warn("Bean was already registered.");
-     * }
-     * }</pre>
-     *
-     * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName The name to assign to the bean in the registry.
-     * @param beanType The class type of the bean to be registered.
-     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
-     */
-    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, String beanName, Class<?> beanType) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType);
-        return registerBeanDefinition(registry, beanName, beanDefinition);
-    }
 
     /**
-     * Registers a bean definition with the specified name, type, and constructor arguments into the given registry.
+     * Register a {@link BeanDefinition} for the specified bean type with an optional name.
      * <p>
-     * This method creates a generic bean definition for the provided bean type using the supplied constructor arguments,
-     * and attempts to register it under the specified bean name. If the bean is successfully registered, it returns {@code true};
-     * otherwise, it returns {@code false}.
-     * </p>
-     *
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * boolean registered = registerBeanDefinition(registry, "myService", MyService.class, "arg1", 123);
-     * if (registered) {
-     *     logger.info("Bean with custom constructor arguments registered successfully.");
-     * } else {
-     *     logger.warn("Bean was already registered.");
-     * }
-     * }</pre>
-     *
-     * @param registry             The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName             The name to assign to the bean in the registry.
-     * @param beanType             The class type of the bean to be registered.
-     * @param constructorArguments The arguments to use for the constructor when instantiating the bean.
-     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
-     */
-    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, String beanName, Class<?> beanType, Object... constructorArguments) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType, constructorArguments);
-        return registerBeanDefinition(registry, beanName, beanDefinition);
-    }
-
-    /**
-     * Register a bean definition with the specified name, type, and role.
-     * <p>
-     * This method creates a generic bean definition for the provided bean type with the specified role,
-     * and attempts to register it under the specified bean name. If the bean is successfully registered,
+     * This method creates a generic bean definition for the provided bean type. If a bean name is provided,
+     * it will be used; otherwise, a unique bean name will be generated automatically based on the bean type.
+     * The bean definition is then registered in the given registry. If the bean is successfully registered,
      * it returns {@code true}; otherwise, it returns {@code false}.
      * </p>
      *
      * <h3>Example Usage</h3>
      * <pre>{@code
-     * boolean registered = registerBeanDefinition(registry, "myService", MyService.class, BeanDefinition.ROLE_INFRASTRUCTURE);
+     * // Register with auto-generated name
+     * boolean registered = registerBeanDefinition(registry, null, MyBean.class);
+     *
+     * // Register with explicit name
+     * boolean registered = registerBeanDefinition(registry, "myCustomBean", MyBean.class);
+     *
      * if (registered) {
-     *     logger.info("Bean with custom role registered successfully.");
+     *     System.out.println("Bean registered successfully.");
      * } else {
-     *     logger.warn("Bean was already registered.");
+     *     System.out.println("Bean was already registered.");
      * }
      * }</pre>
      *
      * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName The name to assign to the bean in the registry.
+     * @param beanName The name to assign to the bean in the registry, or {@code null} to generate a unique name.
      * @param beanType The class type of the bean to be registered.
-     * @param role     The role hint for the bean definition ({@link BeanDefinition#ROLE_APPLICATION},
-     *                 {@link BeanDefinition#ROLE_INFRASTRUCTURE}, or {@link BeanDefinition#ROLE_SUPPORT})
      * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
      */
-    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, String beanName, Class<?> beanType, int role) {
-        BeanDefinition beanDefinition = genericBeanDefinition(beanType, role);
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName, Class<?> beanType) {
+        BeanDefinition beanDefinition = genericBeanDefinition(beanType);
         return registerBeanDefinition(registry, beanName, beanDefinition);
     }
 
     /**
-     * Register a {@link BeanDefinition} with name if absent.
+     * Register a {@link BeanDefinition} for the specified bean type with constructor arguments.
      * <p>
-     * This method attempts to register the given bean definition under the specified name only if there is no existing
-     * bean definition with the same name in the registry. It internally delegates to
-     * {@link #registerBeanDefinition(BeanDefinitionRegistry, String, BeanDefinition, boolean)} with
-     * {@code allowBeanDefinitionOverriding} set to {@code false}.
+     * This method creates a generic bean definition for the provided bean type, applying the specified
+     * constructor arguments. If a bean name is provided, it will be used; otherwise, a unique bean name
+     * will be generated automatically based on the bean type. The bean definition is then registered in
+     * the given registry. If the bean is successfully registered, it returns {@code true}; otherwise,
+     * it returns {@code false}.
      * </p>
      *
      * <h3>Example Usage</h3>
      * <pre>{@code
-     * BeanDefinition beanDefinition = genericBeanDefinition(MyService.class);
-     * String beanName = "myService";
-     * boolean registered = registerBeanDefinition(registry, beanName, beanDefinition);
+     * // Register with auto-generated name and constructor arguments
+     * boolean registered = registerBeanDefinition(registry, null, MyBean.class, "arg1", 42);
+     *
+     * // Register with explicit name and constructor arguments
+     * boolean registered = registerBeanDefinition(registry, "myCustomBean", MyBean.class, "arg1", 42);
+     *
      * if (registered) {
-     *     logger.info("Bean was successfully registered.");
+     *     System.out.println("Bean registered successfully.");
      * } else {
-     *     logger.warn("Bean was already registered and not overridden.");
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry             The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanName             The name to assign to the bean in the registry, or {@code null} to generate a unique name.
+     * @param beanType             The class type of the bean to be registered.
+     * @param constructorArguments The arguments to pass to the bean's constructor.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 Class<?> beanType, Object... constructorArguments) {
+        BeanDefinition beanDefinition = genericBeanDefinition(beanType, constructorArguments);
+        return registerBeanDefinition(registry, beanName, beanDefinition);
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} for the specified bean type with a specific role.
+     * <p>
+     * This method creates a generic bean definition for the provided bean type and assigns it the specified role.
+     * If a bean name is provided, it will be used; otherwise, a unique bean name will be generated automatically
+     * based on the bean type. The bean definition is then registered in the given registry. If the bean is
+     * successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register as an infrastructure bean (ROLE_INFRASTRUCTURE)
+     * boolean registered = registerBeanDefinition(registry, null, MyInfrastructure.class, BeanDefinition.ROLE_INFRASTRUCTURE);
+     *
+     * // Register as a support bean (ROLE_SUPPORT)
+     * boolean registered = registerBeanDefinition(registry, "mySupportBean", MySupport.class, BeanDefinition.ROLE_SUPPORT);
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully with the specified role.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanName The name to assign to the bean in the registry, or {@code null} to generate a unique name.
+     * @param beanType The class type of the bean to be registered.
+     * @param role     The role of the bean definition (e.g., {@link BeanDefinition#ROLE_APPLICATION},
+     *                 {@link BeanDefinition#ROLE_SUPPORT}, or {@link BeanDefinition#ROLE_INFRASTRUCTURE}).
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 Class<?> beanType, int role) {
+        return registerBeanDefinition(registry, beanName, beanType, builder -> builder.setRole(role));
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} for the specified bean type with custom configuration via a builder consumer.
+     * <p>
+     * This method creates a generic bean definition for the provided bean type and applies custom configurations
+     * using the specified {@link Consumer} of {@link BeanDefinitionBuilder}. A unique bean name will be generated
+     * automatically based on the bean type. The bean definition is then registered in the given registry.
+     * If the bean is successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register with auto-generated name and custom property
+     * boolean registered = registerBeanDefinition(registry, MyBean.class, builder ->
+     *     builder.addPropertyValue("myProperty", "myValue")
+     * );
+     *
+     * // Register with auto-generated name and custom constructor argument
+     * boolean registered = registerBeanDefinition(registry, MyBean.class, builder ->
+     *     builder.addConstructorArgValue("arg1")
+     * );
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully with custom configuration.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry        The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanType        The class type of the bean to be registered.
+     * @param builderConsumer A {@link Consumer} that configures the {@link BeanDefinitionBuilder} before building the definition.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, Class<?> beanType,
+                                                 Consumer<BeanDefinitionBuilder> builderConsumer) {
+        return registerBeanDefinition(registry, null, beanType, builderConsumer);
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} for the specified bean type with custom configuration via a builder consumer.
+     * <p>
+     * This method creates a generic bean definition for the provided bean type and applies custom configurations
+     * using the specified {@link Consumer} of {@link BeanDefinitionBuilder}. If a bean name is provided,
+     * it will be used; otherwise, a unique bean name will be generated automatically based on the bean type.
+     * The bean definition is then registered in the given registry. If the bean is successfully registered,
+     * it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register with auto-generated name and custom property
+     * boolean registered = registerBeanDefinition(registry, null, MyBean.class, builder ->
+     *     builder.addPropertyValue("myProperty", "myValue")
+     * );
+     *
+     * // Register with explicit name and custom constructor argument
+     * boolean registered = registerBeanDefinition(registry, "myCustomBean", MyBean.class, builder ->
+     *     builder.addConstructorArgValue("arg1")
+     * );
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully with custom configuration.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry        The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanName        The name to assign to the bean in the registry, or {@code null} to generate a unique name.
+     * @param beanType        The class type of the bean to be registered.
+     * @param builderConsumer A {@link Consumer} that configures the {@link BeanDefinitionBuilder} before building the definition.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 Class<?> beanType, Consumer<BeanDefinitionBuilder> builderConsumer) {
+        AbstractBeanDefinition beanDefinition = genericBeanDefinition(beanType, builderConsumer);
+        return registerBeanDefinition(registry, beanName, beanDefinition);
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} with an optional name into the given registry.
+     * <p>
+     * This method attempts to register the provided bean definition. If a bean name is provided,
+     * it will be used; otherwise, a unique bean name will be generated automatically based on the
+     * bean definition. The registration process respects the default bean overriding settings of the registry.
+     * If the bean is successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register with auto-generated name
+     * BeanDefinition beanDefinition = genericBeanDefinition(MyService.class);
+     * boolean registered = registerBeanDefinition(registry, null, beanDefinition);
+     *
+     * // Register with explicit name
+     * BeanDefinition anotherDefinition = genericBeanDefinition(AnotherService.class);
+     * boolean registered = registerBeanDefinition(registry, "anotherService", anotherDefinition);
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
      * }
      * }</pre>
      *
      * @param registry       The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName       The name to assign to the bean in the registry.
+     * @param beanName       The name to assign to the bean in the registry, or {@code null} to generate a unique name.
      * @param beanDefinition The bean definition to register.
-     * @return Returns {@code true} if the bean definition was registered for the first time; returns {@code false}
-     * if it was already registered and overriding is disabled.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
      */
-    public static final boolean registerBeanDefinition(BeanDefinitionRegistry registry, String beanName, BeanDefinition beanDefinition) {
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 BeanDefinition beanDefinition) {
         return registerBeanDefinition(registry, beanName, beanDefinition, false);
     }
 
     /**
-     * Registers a bean definition with the specified name into the given registry.
+     * Registers a {@link BeanDefinition} with an optional name and overriding control into the given registry.
      * <p>
-     * This method attempts to register the provided bean definition under the specified bean name. If the bean definition
-     * is successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * This method attempts to register the provided bean definition. If a bean name is provided,
+     * it will be used; otherwise, a unique bean name will be generated automatically based on the
+     * bean definition. The registration process respects the {@code allowBeanDefinitionOverriding} flag.
+     * If overriding is not allowed and a bean with the same name already exists, the registration is skipped,
+     * and a warning is logged. If the bean is successfully registered, it returns {@code true}; otherwise,
+     * it returns {@code false}.
      * </p>
-     *
-     * <p>If overriding is not allowed and a bean definition with the same name already exists in the registry, the new
-     * definition will not be registered, a warning log message will be generated, and this method will return
-     * {@code false}.</p>
-     *
-     * <p>If overriding is allowed and a bean definition with the same name already exists, the existing definition will
-     * be replaced with the new one.</p>
      *
      * <h3>Example Usage</h3>
      * <pre>{@code
+     * // Register with auto-generated name, allowing overriding
      * BeanDefinition beanDefinition = genericBeanDefinition(MyService.class);
-     * String beanName = "myService";
-     * boolean allowBeanDefinitionOverriding = false;
+     * boolean registered = registerBeanDefinition(registry, null, beanDefinition, true);
      *
-     * boolean registered = registerBeanDefinition(registry, beanName, beanDefinition, allowBeanDefinitionOverriding);
+     * // Register with explicit name, disallowing overriding
+     * BeanDefinition anotherDefinition = genericBeanDefinition(AnotherService.class);
+     * boolean registered = registerBeanDefinition(registry, "anotherService", anotherDefinition, false);
+     *
      * if (registered) {
-     *     logger.info("Bean was successfully registered.");
+     *     System.out.println("Bean registered successfully.");
      * } else {
-     *     logger.warn("Bean was already registered and not overridden.");
+     *     System.out.println("Bean was not registered (already exists or error).");
      * }
      * }</pre>
      *
      * @param registry                      The {@link BeanDefinitionRegistry} where the bean will be registered.
-     * @param beanName                      The name to assign to the bean in the registry.
+     * @param beanName                      The name to assign to the bean in the registry, or {@code null} to generate a unique name.
      * @param beanDefinition                The bean definition to register.
-     * @param allowBeanDefinitionOverriding Whether the bean definition is allowed to override an existing one.
-     * @return <code>true</code> if registered successfully; <code>false</code> if it was already registered and overriding is disabled.
+     * @param allowBeanDefinitionOverriding Whether to allow overriding of an existing bean definition with the same name.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered or registration failed.
      */
-    public static final boolean registerBeanDefinition(BeanDefinitionRegistry registry, String beanName, BeanDefinition beanDefinition, boolean allowBeanDefinitionOverriding) {
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 BeanDefinition beanDefinition, boolean allowBeanDefinitionOverriding) {
+
+        String actualBeanName = beanName == null ? generateBeanName(beanDefinition, registry) : beanName;
 
         boolean registered = false;
 
-        if (!allowBeanDefinitionOverriding && registry.containsBeanDefinition(beanName)) {
-            BeanDefinition oldBeanDefinition = registry.getBeanDefinition(beanName);
+        if (!allowBeanDefinitionOverriding && registry.containsBeanDefinition(actualBeanName)) {
+            BeanDefinition oldBeanDefinition = registry.getBeanDefinition(actualBeanName);
             if (logger.isWarnEnabled()) {
-                logger.warn("The bean[name : '{}'] definition [{}] was registered!", beanName, oldBeanDefinition);
+                logger.warn("The bean[name : '{}'] definition [{}] was registered!", actualBeanName, oldBeanDefinition);
             }
         } else {
             try {
-                registry.registerBeanDefinition(beanName, beanDefinition);
+                registry.registerBeanDefinition(actualBeanName, beanDefinition);
                 if (logger.isTraceEnabled()) {
-                    logger.trace("The bean[name : '{}' , role : {}] definition [{}] has been registered.", beanName, beanDefinition.getRole(), beanDefinition);
+                    logger.trace("The bean[name : '{}' , role : {}] definition [{}] has been registered.", actualBeanName, beanDefinition.getRole(), beanDefinition);
                 }
                 registered = true;
             } catch (BeanDefinitionStoreException e) {
-                if (logger.isErrorEnabled()) {
-                    logger.error("The bean[name : '{}' , role : {}] definition [{}] can't be registered ", beanName, beanDefinition.getRole(), e);
+                if (logger.isWarnEnabled()) {
+                    logger.warn("The bean[name : '{}' , role : {}] definition [{}] can't be registered ", actualBeanName, beanDefinition.getRole(), e);
                 }
                 registered = false;
             }
@@ -478,21 +600,12 @@ public abstract class BeanRegistrar {
     public static Map<Class, String> registerSpringFactoriesBeans(BeanDefinitionRegistry registry, Class<?>... factoryClasses) {
         // Convert the array of factory classes into a Set for efficient lookup and to avoid duplicates
         Set<Class<?>> factoryClassesSet = ofSet(factoryClasses);
+        ConfigurableListableBeanFactory beanFactory = asConfigurableListableBeanFactory(registry);
+        ClassLoader classLoader = beanFactory.getBeanClassLoader();
         Map<Class, String> registeredBeanClassesAndNames = newHashMap(factoryClassesSet.size() * 2);
         for (Class<?> factoryClass : factoryClassesSet) {
-            ClassLoader classLoader = factoryClass.getClassLoader();
-            List<String> factoryImplClassNames = loadFactoryNames(factoryClass, classLoader);
-            for (String factoryImplClassName : factoryImplClassNames) {
-                Class<?> factoryImplClass = resolveClassName(factoryImplClassName, classLoader);
-                String beanName = BeanUtils.generateBeanName(factoryImplClassName);
-                if (registerInfrastructureBean(registry, beanName, factoryImplClass)) {
-                    registeredBeanClassesAndNames.put(factoryImplClass, beanName);
-                } else {
-                    if (logger.isWarnEnabled()) {
-                        logger.warn("The Factory Class bean[ class : '{}' ] has been registered with bean name {}", factoryImplClassName, beanName);
-                    }
-                }
-            }
+            Set<Class<?>> factoryImplClasses = (Set) loadFactoryClasses(factoryClass, classLoader);
+            registeredBeanClassesAndNames.putAll(registerGenericBeans(registry, factoryImplClasses));
         }
         return unmodifiableMap(registeredBeanClassesAndNames);
     }
@@ -611,6 +724,132 @@ public abstract class BeanRegistrar {
         } else {
             registerFactoryBean(registry, beanName, bean, primary);
         }
+    }
+
+    /**
+     * Registers generic bean definitions for the specified collection of bean classes into the given registry.
+     * <p>
+     * This method iterates through the provided collection of bean classes, creates a generic bean definition for each,
+     * generates a unique bean name, and attempts to register it in the registry. It returns an unmodifiable map
+     * containing the successfully registered bean classes mapped to their assigned bean names.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * List<Class<?>> beanClasses = Arrays.asList(MyService.class, MyRepository.class);
+     * Map<Class<?>, String> registeredBeans = registerGenericBeans(registry, beanClasses);
+     * registeredBeans.forEach((clazz, name) -> {
+     *     logger.info("Registered bean: {} of type: {}", name, clazz.getName());
+     * });
+     * }</pre>
+     *
+     * @param registry    The {@link BeanDefinitionRegistry} where the beans will be registered.
+     * @param beanClasses A collection of class types of the beans to be registered.
+     * @return An unmodifiable map of registered bean classes to their assigned bean names.
+     */
+    public static Map<Class<?>, String> registerGenericBeans(BeanDefinitionRegistry registry, Collection<Class<?>> beanClasses) {
+        return registerGenericBeans(registry, beanClasses.toArray(EMPTY_CLASS_ARRAY));
+    }
+
+    /**
+     * Registers generic bean definitions for the specified bean classes into the given registry.
+     * <p>
+     * This method iterates through the provided bean classes, creates a generic bean definition for each,
+     * generates a unique bean name, and attempts to register it in the registry. It returns an unmodifiable map
+     * containing the successfully registered bean classes mapped to their assigned bean names.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * Map<Class<?>, String> registeredBeans = registerGenericBeans(registry, MyService.class, MyRepository.class);
+     * registeredBeans.forEach((clazz, name) -> {
+     *     logger.info("Registered bean: {} of type: {}", name, clazz.getName());
+     * });
+     * }</pre>
+     *
+     * @param registry    The {@link BeanDefinitionRegistry} where the beans will be registered.
+     * @param beanClasses An array of class types of the beans to be registered.
+     * @return An unmodifiable map of registered bean classes to their assigned bean names.
+     */
+    public static Map<Class<?>, String> registerGenericBeans(BeanDefinitionRegistry registry, Class<?>... beanClasses) {
+        int length = length(beanClasses);
+        if (length == 0) {
+            return emptyMap();
+        }
+        Map<Class<?>, String> beanTypesAndNames = newFixedHashMap(length);
+        for (int i = 0; i < length; i++) {
+            Class<?> beanClass = beanClasses[i];
+            Map.Entry<String, Boolean> result = registerGenericBean(registry, beanClass);
+            String beanName = result.getKey();
+            beanTypesAndNames.put(beanClass, beanName);
+        }
+        return unmodifiableMap(beanTypesAndNames);
+    }
+
+
+    /**
+     * Registers a generic bean definition for the specified bean class into the given registry.
+     * <p>
+     * This method creates a generic bean definition for the provided bean class, generates a unique bean name
+     * using the default {@link BeanNameGenerator} ({@link GenericBeanNameGenerator#INSTANCE}), and attempts to
+     * register it in the registry. It returns an immutable entry containing the generated bean name and a boolean
+     * indicating whether the registration was successful.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * Entry<String, Boolean> result = registerGenericBean(registry, MyService.class);
+     * String beanName = result.getKey(); // "myService"
+     * boolean registered = result.getValue();
+     * if (registered) {
+     *     logger.info("Bean registered with name: {}", beanName);
+     * } else {
+     *     logger.warn("Bean with name '{}' was already registered.", beanName);
+     * }
+     * }</pre>
+     *
+     * @param registry  The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanClass The class type of the bean to be registered.
+     * @return An immutable {@link Map.Entry} where the key is the generated bean name and the value is {@code true} if
+     * the bean was successfully registered, or {@code false} if it was already present and overriding is disabled.
+     */
+    public static Map.Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass) {
+        return registerGenericBean(registry, beanClass, INSTANCE);
+    }
+
+    /**
+     * Registers a generic bean definition for the specified bean class into the given registry using a custom bean name generator.
+     * <p>
+     * This method creates a generic bean definition for the provided bean class, generates a unique bean name using the
+     * specified {@link BeanNameGenerator}, and attempts to register it in the registry. It returns an immutable entry
+     * containing the generated bean name and a boolean indicating whether the registration was successful.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * BeanNameGenerator customGenerator = new CustomBeanNameGenerator();
+     * Entry<String, Boolean> result = registerGenericBean(registry, MyService.class, customGenerator);
+     * String beanName = result.getKey();
+     * boolean registered = result.getValue();
+     * if (registered) {
+     *     logger.info("Bean registered with name: {}", beanName);
+     * } else {
+     *     logger.warn("Bean with name '{}' was already registered.", beanName);
+     * }
+     * }</pre>
+     *
+     * @param registry          The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanClass         The class type of the bean to be registered.
+     * @param beanNameGenerator The {@link BeanNameGenerator} to use for generating the bean name.
+     * @return An immutable {@link Map.Entry} where the key is the generated bean name and the value is {@code true} if
+     * the bean was successfully registered, or {@code false} if it was already present and overriding is disabled.
+     */
+    public static Map.Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass,
+                                                                 BeanNameGenerator beanNameGenerator) {
+        BeanDefinition beanDefinition = genericBeanDefinition(beanClass);
+        String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
+        boolean registered = registerBeanDefinition(registry, beanName, beanDefinition);
+        return immutableEntry(beanName, registered);
     }
 
     private BeanRegistrar() {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/GenericBeanNameGenerator.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/GenericBeanNameGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.beans.factory.support;
+
+import io.microsphere.spring.beans.BeanUtils;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+
+import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.resolveBeanType;
+
+/**
+ * Generic {@link BeanNameGenerator}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see BeanNameGenerator
+ * @since 1.0.0
+ */
+public class GenericBeanNameGenerator implements BeanNameGenerator {
+
+    /**
+     * Singleton instance of {@link GenericBeanNameGenerator}
+     */
+    public static final BeanNameGenerator INSTANCE = new GenericBeanNameGenerator();
+
+    @Override
+    public String generateBeanName(BeanDefinition definition, BeanDefinitionRegistry registry) {
+        AbstractBeanDefinition abstractBeanDefinition = (AbstractBeanDefinition) definition;
+        Class<?> beanType = resolveBeanType(abstractBeanDefinition);
+        return BeanUtils.generateBeanName(beanType);
+    }
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ExposingClassPathBeanDefinitionScanner.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ExposingClassPathBeanDefinitionScanner.java
@@ -59,7 +59,6 @@ import static org.springframework.context.annotation.AnnotationConfigUtils.regis
  * @see BeanDefinitionRegistry
  * @see SingletonBeanRegistry
  * @since 1.0.0
- *
  */
 public class ExposingClassPathBeanDefinitionScanner extends ClassPathBeanDefinitionScanner {
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/SpringFactoriesLoaderUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/SpringFactoriesLoaderUtils.java
@@ -27,8 +27,10 @@ import org.springframework.core.io.support.SpringFactoriesLoader;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Set;
 
 import static io.microsphere.collection.ListUtils.newArrayList;
+import static io.microsphere.collection.SetUtils.newFixedHashSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.invokeAwareInterfaces;
 import static io.microsphere.spring.beans.BeanUtils.invokeBeanInterfaces;
@@ -38,12 +40,13 @@ import static io.microsphere.spring.context.ApplicationContextUtils.asApplicatio
 import static io.microsphere.spring.context.ApplicationContextUtils.asConfigurableApplicationContext;
 import static io.microsphere.spring.core.io.ResourceLoaderUtils.nullSafeClassLoader;
 import static io.microsphere.util.ArrayUtils.length;
+import static io.microsphere.util.ClassLoaderUtils.resolveClass;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static org.springframework.beans.BeanUtils.instantiateClass;
 import static org.springframework.core.io.support.SpringFactoriesLoader.FACTORIES_RESOURCE_LOCATION;
-import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactoryNames;
 import static org.springframework.util.ClassUtils.resolveClassName;
 import static org.springframework.util.StringUtils.arrayToCommaDelimitedString;
 
@@ -58,10 +61,102 @@ public abstract class SpringFactoriesLoaderUtils implements Utils {
 
     private static final Logger logger = getLogger(SpringFactoriesLoaderUtils.class);
 
+    /**
+     * Load the fully qualified classes of factory implementations of the
+     * given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION}, using the default class loader.
+     * <p>If a particular implementation class name is discovered more than once
+     * for the given factory type, duplicates will be ignored.
+     *
+     * @param factoryType the interface or abstract class representing the factory
+     * @throws IllegalArgumentException if an error occurs while loading factory names
+     */
+    public static <T> Set<Class<T>> loadFactoryClasses(Class<T> factoryType) {
+        return loadFactoryClasses(factoryType, null);
+    }
+
+    /**
+     * Load the fully qualified classes of factory implementations of the
+     * given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION}, using the given class loader.
+     * <p>If a particular implementation class name is discovered more than once
+     * for the given factory type, duplicates will be ignored.
+     *
+     * @param factoryType the interface or abstract class representing the factory
+     * @param classLoader the ClassLoader to use for loading resources; can be
+     *                    {@code null} to use the default
+     * @throws IllegalArgumentException if an error occurs while loading factory names
+     */
+    public static <T> Set<Class<T>> loadFactoryClasses(Class<?> factoryType, @Nullable ClassLoader classLoader) {
+        List<String> factoryClassNames = loadFactoryNames(factoryType, classLoader);
+        Set<Class<T>> factoryClasses = newFixedHashSet(factoryClassNames.size());
+        for (String factoryClassName : factoryClassNames) {
+            Class<T> factoryClass = (Class<T>) resolveClass(factoryClassName, classLoader);
+            factoryClasses.add(factoryClass);
+        }
+        return unmodifiableSet(factoryClasses);
+    }
+
+    /**
+     * Load the fully qualified class names of factory implementations of the
+     * given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION}, using the default class loader.
+     * <p>If a particular implementation class name is discovered more than once
+     * for the given factory type, duplicates will be ignored.
+     *
+     * @param factoryType the interface or abstract class representing the factory
+     * @throws IllegalArgumentException if an error occurs while loading factory names
+     */
+    public static List<String> loadFactoryNames(Class<?> factoryType) {
+        return loadFactoryNames(factoryType, null);
+    }
+
+    /**
+     * Load the fully qualified class names of factory implementations of the
+     * given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION}, using the given class loader.
+     * <p>If a particular implementation class name is discovered more than once
+     * for the given factory type, duplicates will be ignored.
+     *
+     * @param factoryType the interface or abstract class representing the factory
+     * @param classLoader the ClassLoader to use for loading resources; can be
+     *                    {@code null} to use the default
+     * @throws IllegalArgumentException if an error occurs while loading factory names
+     */
+    public static List<String> loadFactoryNames(Class<?> factoryType, @Nullable ClassLoader classLoader) {
+        List<String> factoryClassNames = SpringFactoriesLoader.loadFactoryNames(factoryType, classLoader);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Loaded factory class names of type {} : {}", factoryType.getName(), factoryClassNames);
+        }
+        return factoryClassNames;
+    }
+
+    /**
+     * Load the factory implementations of the given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION},
+     * using the given {@link ApplicationContext}'s class loader.
+     * <p>The returned factories will be invoked with {@link org.springframework.beans.factory.Aware} interfaces
+     * and other bean lifecycle callbacks if the context is a {@link ConfigurableApplicationContext}.
+     *
+     * @param context     the {@link ApplicationContext} to use for loading resources and invoking callbacks; can be {@code null}
+     * @param factoryType the interface or abstract class representing the factory
+     * @param <T>         the factory type
+     * @return the list of instantiated factory objects
+     * @throws IllegalArgumentException if an error occurs while loading or instantiating factory classes
+     * @see SpringFactoriesLoader#loadFactories(Class, ClassLoader)
+     */
     public static <T> List<T> loadFactories(@Nullable ApplicationContext context, Class<T> factoryType) {
         return loadFactories(asConfigurableApplicationContext(context), factoryType);
     }
 
+    /**
+     * Load the factory implementations of the given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION},
+     * using the given {@link ConfigurableApplicationContext}'s class loader.
+     * <p>The returned factories will be invoked with {@link org.springframework.beans.factory.Aware} interfaces
+     * and other bean lifecycle callbacks.
+     *
+     * @param context     the {@link ConfigurableApplicationContext} to use for loading resources and invoking callbacks; can be {@code null}
+     * @param factoryType the interface or abstract class representing the factory
+     * @param <T>         the factory type
+     * @return the list of instantiated factory objects
+     * @throws IllegalArgumentException if an error occurs while loading or instantiating factory classes
+     * @see SpringFactoriesLoader#loadFactories(Class, ClassLoader)
+     */
     public static <T> List<T> loadFactories(@Nullable ConfigurableApplicationContext context, Class<T> factoryType) {
         ClassLoader classLoader = nullSafeClassLoader(context);
         List<T> factories = SpringFactoriesLoader.loadFactories(factoryType, classLoader);
@@ -72,20 +167,37 @@ public abstract class SpringFactoriesLoaderUtils implements Utils {
         return factories;
     }
 
-    public static <T> List<T> loadFactories(@Nullable ConfigurableApplicationContext context, Class<T> factoryClass, Object... args) {
+    /**
+     * Load the factory implementations of the given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION},
+     * using the given {@link ConfigurableApplicationContext}'s class loader and constructor arguments.
+     * <p>The returned factories will be invoked with {@link org.springframework.beans.factory.Aware} interfaces
+     * and other bean lifecycle callbacks.
+     * <p>This method attempts to find a matching constructor for each factory implementation class based on the
+     * provided arguments. If no arguments are provided, it delegates to {@link #loadFactories(ConfigurableApplicationContext, Class)}.
+     *
+     * @param context     the {@link ConfigurableApplicationContext} to use for loading resources and invoking callbacks; can be {@code null}
+     * @param factoryType the interface or abstract class representing the factory
+     * @param args        the constructor arguments to use when instantiating the factory implementations
+     * @param <T>         the factory type
+     * @return the list of instantiated factory objects
+     * @throws IllegalArgumentException if an error occurs while loading or instantiating factory classes,
+     *                                  or if no suitable constructor is found for the provided arguments
+     * @see SpringFactoriesLoader#loadFactories(Class, ClassLoader)
+     */
+    public static <T> List<T> loadFactories(@Nullable ConfigurableApplicationContext context, Class<T> factoryType, Object... args) {
         int argsLength = length(args);
         if (argsLength < 1) {
-            return loadFactories(context, factoryClass);
+            return loadFactories(context, factoryType);
         }
 
         ClassLoader classLoader = nullSafeClassLoader(context);
-        List<String> factoryClassNames = loadFactoryNames(factoryClass, classLoader);
+        List<String> factoryClassNames = loadFactoryNames(factoryType, classLoader);
 
         int factorySize = factoryClassNames.size();
 
         if (factorySize < 1) {
             if (logger.isTraceEnabled()) {
-                logger.trace("No factory class {} were loaded from SpringFactoriesLoader[{}]", factoryClass.getName(),
+                logger.trace("No factory class {} were loaded from SpringFactoriesLoader[{}]", factoryType.getName(),
                         FACTORIES_RESOURCE_LOCATION);
             }
             return emptyList();
@@ -104,6 +216,20 @@ public abstract class SpringFactoriesLoaderUtils implements Utils {
         return unmodifiableList(factories);
     }
 
+    /**
+     * Load the factory implementations of the given type from {@value SpringFactoriesLoader#FACTORIES_RESOURCE_LOCATION},
+     * using the given {@link BeanFactory}'s class loader.
+     * <p>If the {@link BeanFactory} is an {@link ApplicationContext}, it delegates to {@link #loadFactories(ApplicationContext, Class)}.
+     * Otherwise, it uses the {@link BeanFactory}'s bean class loader to load factories and invokes
+     * {@link org.springframework.beans.factory.Aware} interfaces on the instantiated factories.
+     *
+     * @param beanFactory the {@link BeanFactory} to use for loading resources and invoking callbacks; can be {@code null}
+     * @param factoryType the interface or abstract class representing the factory
+     * @param <T>         the factory type
+     * @return the list of instantiated factory objects
+     * @throws IllegalArgumentException if an error occurs while loading or instantiating factory classes
+     * @see SpringFactoriesLoader#loadFactories(Class, ClassLoader)
+     */
     public static <T> List<T> loadFactories(@Nullable BeanFactory beanFactory, Class<T> factoryType) {
         ApplicationContext context = asApplicationContext(beanFactory);
         if (context != null) {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
@@ -21,6 +21,7 @@ import io.microsphere.spring.test.domain.User;
 import org.junit.Test;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
+import java.util.Map;
 import java.util.Set;
 
 import static io.microsphere.collection.Sets.ofSet;
@@ -29,7 +30,9 @@ import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
 import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.beans.BeanSource.values;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * {@link BeanSource} Test
@@ -53,9 +56,38 @@ public class BeanSourceTest {
     public void testGetBeanTypes() {
         testInSpringContainer(context -> {
             ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
-            Set<Class<User>> beanTypes = BEAN_FACTORY.getBeanTypes(beanFactory, User.class);
-            assertEquals(1, beanTypes.size());
-            assertEquals(ofSet(User.class), beanTypes);
+            assertBeanTypes(beanFactory, BEAN_FACTORY);
+            assertBeanTypes(beanFactory, SPRING_FACTORIES);
+            assertBeanTypes(beanFactory, JAVA_SERVICE_PROVIDER);
         }, User.class);
+    }
+
+    @Test
+    public void testRegisterBeans() {
+        assertRegisterBeans(BEAN_FACTORY);
+        assertRegisterBeans(SPRING_FACTORIES);
+        assertRegisterBeans(JAVA_SERVICE_PROVIDER);
+    }
+
+    void assertBeanTypes(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
+        Set<Class<User>> beanTypes = beanSource.getBeanTypes(beanFactory, User.class);
+        assertEquals(1, beanTypes.size());
+        assertEquals(ofSet(User.class), beanTypes);
+    }
+
+    void assertRegisterBeans(BeanSource beanSource) {
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            assertRegisterBeans(beanFactory, beanSource);
+        }, User.class);
+    }
+
+    void assertRegisterBeans(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
+        Map<Class<?>, String> beanTypesAndNames = beanSource.registerBeans(beanFactory, User.class);
+        assertEquals(1, beanTypesAndNames.size());
+        assertEquals("user", beanTypesAndNames.get(User.class));
+
+        beanTypesAndNames = beanSource.registerBeans(beanFactory);
+        assertSame(emptyMap(), beanTypesAndNames);
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
@@ -28,8 +28,10 @@ import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
 import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
 import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
+import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.BeanSource.values;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
+import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -69,6 +71,24 @@ public class BeanSourceTest {
         assertRegisterBeans(JAVA_SERVICE_PROVIDER);
     }
 
+    @Test
+    public void testRegisterBeansOnStatic() {
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            Map<Class<?>, String> beanTypesAndNames = registerBeans(beanFactory, ofArray(BEAN_FACTORY), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(beanFactory, ofArray(BEAN_FACTORY, SPRING_FACTORIES), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(beanFactory, ofArray(BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(beanFactory, values());
+            assertSame(emptyMap(), beanTypesAndNames);
+        }, User.class);
+    }
+
     void assertBeanTypes(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
         Set<Class<User>> beanTypes = beanSource.getBeanTypes(beanFactory, User.class);
         assertEquals(1, beanTypes.size());
@@ -84,10 +104,14 @@ public class BeanSourceTest {
 
     void assertRegisterBeans(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
         Map<Class<?>, String> beanTypesAndNames = beanSource.registerBeans(beanFactory, User.class);
-        assertEquals(1, beanTypesAndNames.size());
-        assertEquals("user", beanTypesAndNames.get(User.class));
+        assertBeans(beanTypesAndNames);
 
         beanTypesAndNames = beanSource.registerBeans(beanFactory);
         assertSame(emptyMap(), beanTypesAndNames);
+    }
+
+    void assertBeans(Map<Class<?>, String> beanTypesAndNames) {
+        assertEquals(1, beanTypesAndNames.size());
+        assertEquals("user", beanTypesAndNames.get(User.class));
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
@@ -17,12 +17,18 @@
 
 package io.microsphere.spring.beans;
 
+import io.microsphere.spring.test.domain.User;
 import org.junit.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
+import java.util.Set;
+
+import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
 import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
 import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.beans.BeanSource.values;
+import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -41,5 +47,15 @@ public class BeanSourceTest {
         assertEquals(BEAN_FACTORY, values[0]);
         assertEquals(SPRING_FACTORIES, values[1]);
         assertEquals(JAVA_SERVICE_PROVIDER, values[2]);
+    }
+
+    @Test
+    public void testGetBeanTypes() {
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            Set<Class<User>> beanTypes = BEAN_FACTORY.getBeanTypes(beanFactory, User.class);
+            assertEquals(1, beanTypes.size());
+            assertEquals(ofSet(User.class), beanTypes);
+        }, User.class);
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 
 import static io.microsphere.collection.SetUtils.ofSet;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asAutowireCapableBeanFactory;
@@ -45,6 +46,7 @@ import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asHierarchica
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asListableBeanFactory;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanClassLoader;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanPostProcessors;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanTypes;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeans;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getOptionalBean;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getResolvableDependencyTypes;
@@ -52,6 +54,7 @@ import static io.microsphere.spring.beans.factory.BeanFactoryUtils.isBeanDefinit
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.isDefaultListableBeanFactory;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.nullSafeBeanClassLoader;
 import static io.microsphere.spring.context.ApplicationContextUtils.APPLICATION_CONTEXT_AWARE_PROCESSOR_CLASS_NAME;
+import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
 import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
 import static io.microsphere.util.ArrayUtils.of;
 import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
@@ -269,6 +272,19 @@ public class BeanFactoryUtilsTest {
     public void testNullSafeBeanClassLoader() {
         assertSame(getDefaultClassLoader(), nullSafeBeanClassLoader(null));
         assertSame(this.beanFactory.getBeanClassLoader(), nullSafeBeanClassLoader(this.beanFactory));
+    }
+
+    @Test
+    public void testGetBeanTypes() {
+        testInSpringContainer(context -> {
+            Set<Class<BaseTestBean>> beanTypes = getBeanTypes(context, BaseTestBean.class);
+            assertEquals(ofSet(BaseTestBean.class, BaseTestBean2.class), beanTypes);
+        }, BaseTestBean.class, BaseTestBean2.class);
+
+        testInSpringContainer(context -> {
+            Set<Class<BaseTestBean>> beanTypes = getBeanTypes(context, BaseTestBean.class);
+            assertEquals(ofSet(BaseTestBean.class), beanTypes);
+        }, BaseTestBean.class);
     }
 
     @Component("baseTestBean2")

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
@@ -44,7 +44,9 @@ import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurabl
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asDefaultListableBeanFactory;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asHierarchicalBeanFactory;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asListableBeanFactory;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanClass;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanClassLoader;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanDefinition;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanPostProcessors;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanTypes;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeans;
@@ -284,6 +286,24 @@ public class BeanFactoryUtilsTest {
         testInSpringContainer(context -> {
             Set<Class<BaseTestBean>> beanTypes = getBeanTypes(context, BaseTestBean.class);
             assertEquals(ofSet(BaseTestBean.class), beanTypes);
+        }, BaseTestBean.class);
+    }
+
+    @Test
+    public void testGetBeanClass() {
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            assertSame(BaseTestBean.class, getBeanClass(beanFactory, "baseTestBean"));
+            assertNull(getBeanClass(beanFactory, "baseTestBean2"));
+        }, BaseTestBean.class);
+    }
+
+    @Test
+    public void testGetBeanDefinition() {
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            assertNotNull(getBeanDefinition(beanFactory, "baseTestBean"));
+            assertNull(getBeanDefinition(beanFactory, "baseTestBean2"));
         }, BaseTestBean.class);
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -42,10 +43,13 @@ import static io.microsphere.spring.beans.factory.support.BeanRegistrar.hasAlias
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBean;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerFactoryBean;
+import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerGenericBean;
+import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerGenericBeans;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerInfrastructureBean;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerSingleton;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerSpringFactoriesBeans;
 import static java.beans.Introspector.decapitalize;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -126,6 +130,12 @@ public class BeanRegistrarTest {
     }
 
     @Test
+    public void testRegisterBeanDefinitionWithBuilder() {
+        String beanName = "io.microsphere.spring.test.domain.User#0";
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class, builder -> builder.setRole(ROLE_INFRASTRUCTURE)), true, ROLE_INFRASTRUCTURE, beanName);
+    }
+
+    @Test
     public void testRegisterSingleton() {
         registerUserAsSingleton();
     }
@@ -148,7 +158,7 @@ public class BeanRegistrarTest {
         Map<Class, String> classStringMap = registerSpringFactoriesBeans((BeanFactory) this.beanFactory, Bean.class);
         assertEquals(2, classStringMap.size());
         classStringMap = registerSpringFactoriesBeans((BeanFactory) this.beanFactory, Bean.class);
-        assertEquals(0, classStringMap.size());
+        assertEquals(2, classStringMap.size());
 
         assertTrue(this.beanFactory.containsBean(decapitalize(TestBean.class.getSimpleName())));
         assertTrue(this.beanFactory.containsBean(decapitalize(TestBean2.class.getSimpleName())));
@@ -162,6 +172,32 @@ public class BeanRegistrarTest {
     @Test
     public void testRegisterBean() {
         testRegisterBean((beanName, bean) -> registerBean(this.beanFactory, beanName, bean));
+    }
+
+    @Test
+    public void testRegisterGenericBeans() {
+        String beanName = "user";
+        Map<Class<?>, String> beanTypesAndNames = registerGenericBeans(this.beanFactory, User.class);
+        assertEquals(1, beanTypesAndNames.size());
+        assertTrue(beanTypesAndNames.containsKey(User.class));
+        assertEquals(beanName, beanTypesAndNames.get(User.class));
+    }
+
+    @Test
+    public void testRegisterGenericBeansOnEmptyBeanClasses() {
+        assertEquals(emptyMap(), registerGenericBeans(this.beanFactory));
+    }
+
+    @Test
+    public void testRegisterGenericBean() {
+        String beanName = "user";
+        Entry<String, Boolean> beanNameAndRegistered = registerGenericBean(this.beanFactory, User.class);
+        assertEquals(beanName, beanNameAndRegistered.getKey());
+        assertTrue(beanNameAndRegistered.getValue());
+
+        beanNameAndRegistered = registerGenericBean(this.beanFactory, User.class);
+        assertEquals(beanName, beanNameAndRegistered.getKey());
+        assertFalse(beanNameAndRegistered.getValue());
     }
 
     private void testRegisterBean(BiConsumer<String, Object> beanConsumer) {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/CompositeAutowireCandidateResolvingListenerTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/CompositeAutowireCandidateResolvingListenerTest.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.config.DependencyDescriptor;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.microsphere.collection.ListUtils.newArrayList;
+import static io.microsphere.collection.ListUtils.newLinkedList;
 import static io.microsphere.collection.Lists.ofList;
 import static io.microsphere.reflect.FieldUtils.findField;
 import static java.util.Collections.emptyList;
@@ -42,14 +42,16 @@ public class CompositeAutowireCandidateResolvingListenerTest {
 
     @Test
     public void testConstructorWithEmptyListThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> new CompositeAutowireCandidateResolvingListener(emptyList()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CompositeAutowireCandidateResolvingListener(emptyList()));
     }
 
     @Test
     public void testConstructorWithNullElementThrowsException() {
-        List<AutowireCandidateResolvingListener> listeners = newArrayList();
+        List<AutowireCandidateResolvingListener> listeners = newLinkedList();
         listeners.add(null);
-        assertThrows(IllegalArgumentException.class, () -> new CompositeAutowireCandidateResolvingListener(listeners));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CompositeAutowireCandidateResolvingListener(listeners));
     }
 
     @Test
@@ -118,7 +120,8 @@ public class CompositeAutowireCandidateResolvingListenerTest {
             }
         };
 
-        CompositeAutowireCandidateResolvingListener composite = new CompositeAutowireCandidateResolvingListener(ofList(l1));
+        CompositeAutowireCandidateResolvingListener composite =
+                new CompositeAutowireCandidateResolvingListener(ofList(l1));
 
         // Add additional listener
         composite.addListeners(ofList(l2));

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/GenericBeanNameGeneratorTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/GenericBeanNameGeneratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.beans.factory.support;
+
+
+import io.microsphere.spring.beans.BeanUtils;
+import io.microsphere.spring.test.domain.User;
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+
+import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.genericBeanDefinition;
+import static io.microsphere.spring.beans.factory.support.GenericBeanNameGenerator.INSTANCE;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * {@link GenericBeanNameGenerator} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see GenericBeanNameGenerator
+ * @since 1.0.0
+ */
+public class GenericBeanNameGeneratorTest {
+
+    @Test
+    public void testGenerateBeanName() {
+        asserBeanName(User.class);
+        asserBeanName(GenericBeanNameGenerator.class);
+        asserBeanName(GenericBeanNameGeneratorTest.class);
+    }
+
+    void asserBeanName(Class<?> beanType) {
+        BeanDefinition beanDefinition = genericBeanDefinition(beanType);
+        String beanName = INSTANCE.generateBeanName(beanDefinition, null);
+        assertEquals(BeanUtils.generateBeanName(beanType), beanName);
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/SpringFactoriesLoaderUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/SpringFactoriesLoaderUtilsTest.java
@@ -34,9 +34,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 
 import java.util.List;
+import java.util.Set;
 
 import static io.microsphere.logging.test.junit4.LoggingLevelsRule.levels;
 import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactories;
+import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryClasses;
+import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryNames;
 import static io.microsphere.util.ArrayUtils.EMPTY_OBJECT_ARRAY;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Collections.emptyList;
@@ -67,29 +70,43 @@ public class SpringFactoriesLoaderUtilsTest {
 
     @Before
     public void setUp() {
-        context = new GenericApplicationContext();
-        beanFactory = context.getDefaultListableBeanFactory();
-        context.refresh();
+        this.context = new GenericApplicationContext();
+        this.beanFactory = context.getDefaultListableBeanFactory();
+        this.context.refresh();
     }
 
     @After
     public void tearDown() {
-        context.close();
+        this.context.close();
+    }
+
+    @Test
+    public void testLoadFactoryClasses() {
+        Set<Class<Object>> factoryClasses = loadFactoryClasses(User.class, this.context.getClassLoader());
+        assertEquals(1, factoryClasses.size());
+        assertEquals(factoryClasses, loadFactoryClasses(User.class));
+    }
+
+    @Test
+    public void testLoadFactoryNames() {
+        List<String> factoryNames = loadFactoryNames(User.class, this.context.getClassLoader());
+        assertEquals(1, factoryNames.size());
+        assertEquals(factoryNames, loadFactoryNames(User.class));
     }
 
     @Test
     public void testLoadFactories() {
-        testLoadFactoriesFromContext(beanFactory, context);
-        testLoadFactoriesFromBeanFactory(beanFactory);
+        testLoadFactoriesFromContext(this.beanFactory, this.context);
+        testLoadFactoriesFromBeanFactory(this.beanFactory);
         testLoadFactoriesFromBeanFactory(this.context);
     }
 
     @Test
     public void testLoadFactoriesWithArguments() {
-        List<User> users = loadFactories(context, User.class, EMPTY_OBJECT_ARRAY);
+        List<User> users = loadFactories(this.context, User.class, EMPTY_OBJECT_ARRAY);
         assertUser(users);
 
-        users = loadFactories(context, User.class, ARGS);
+        users = loadFactories(this.context, User.class, ARGS);
         assertUser(users, ARGS);
 
         users = loadFactories(null, User.class, ARGS);
@@ -98,12 +115,12 @@ public class SpringFactoriesLoaderUtilsTest {
 
     @Test
     public void testLoadFactoriesWithArgumentsOnConstructorNotFound() {
-        assertThrows(IllegalArgumentException.class, () -> loadFactories(context, User.class, 18, "Mercy"));
+        assertThrows(IllegalArgumentException.class, () -> loadFactories(this.context, User.class, 18, "Mercy"));
     }
 
     @Test
     public void testLoadFactoriesOnNotFound() {
-        assertSame(emptyList(), loadFactories(context, UserFactory.class, ARGS));
+        assertSame(emptyList(), loadFactories(this.context, UserFactory.class, ARGS));
         assertSame(emptyList(), loadFactories(null, UserFactory.class, ARGS));
     }
 

--- a/microsphere-spring-context/src/test/resources/META-INF/services/io.microsphere.spring.test.domain.User
+++ b/microsphere-spring-context/src/test/resources/META-INF/services/io.microsphere.spring.test.domain.User
@@ -1,0 +1,1 @@
+io.microsphere.spring.test.domain.User

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <microsphere-java.version>0.3.6</microsphere-java.version>
         <microsphere-logging.version>0.1.14</microsphere-logging.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>
         <tomcat.version>9.0.117</tomcat.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <microsphere-java.version>0.3.6</microsphere-java.version>
         <microsphere-logging.version>0.1.14</microsphere-logging.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>
         <tomcat.version>9.0.117</tomcat.version>


### PR DESCRIPTION
This pull request introduces significant enhancements to the bean type discovery and registration mechanisms in the Microsphere Spring Context module. The changes include new utility methods for retrieving bean types and classes from a `BeanFactory`, improvements to bean registration logic, and the addition of a generic bean name generator. These updates improve flexibility, code reuse, and consistency when working with different bean sources (BeanFactory, Spring Factories, Java Service Provider).

**Bean Type Discovery and Registration Enhancements**

* Added new methods in `BeanFactoryUtils` to retrieve actual bean types and classes from a `BeanFactory`, including overloaded methods for fine-grained control and improved documentation.
* Enhanced the `BeanSource` enum to provide source-specific implementations for discovering and registering beans from various sources, and added unified registration logic for beans. [[1]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdR20-R43) [[2]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdL43-R166)

**Bean Definition and Name Generation Improvements**

* Updated `BeanDefinitionUtils.resolveBeanType` to accept `AbstractBeanDefinition` instead of `RootBeanDefinition`, improving compatibility and flexibility. [[1]](diffhunk://#diff-feebe60276cbae666a44f2676f2c3a24cb6397420ba1de0a15d7d696e6150379L246-R246) [[2]](diffhunk://#diff-feebe60276cbae666a44f2676f2c3a24cb6397420ba1de0a15d7d696e6150379L257-R261) [[3]](diffhunk://#diff-feebe60276cbae666a44f2676f2c3a24cb6397420ba1de0a15d7d696e6150379L291-R291)
* Introduced a new `GenericBeanNameGenerator` class that generates bean names based on resolved bean types, providing a consistent naming strategy.

**Internal Utility and Code Consistency Updates**

* Added and refactored imports and static utility usages to support new features and improve code clarity in utility classes. [[1]](diffhunk://#diff-0512a7026772b4c2404eb3886fa7c5dbc47def7090773de8be53d3d6b550fb96R19-R31) [[2]](diffhunk://#diff-0512a7026772b4c2404eb3886fa7c5dbc47def7090773de8be53d3d6b550fb96R43-R53) [[3]](diffhunk://#diff-92f787fcba3a65e0cbe0c105c35ab80953e2232e920aff61a1589d3e8f600e6cR30-R33) [[4]](diffhunk://#diff-92f787fcba3a65e0cbe0c105c35ab80953e2232e920aff61a1589d3e8f600e6cR43-L46)
* Minor formatting and documentation adjustments for clarity and consistency.

These changes collectively make it easier to work with beans from multiple sources and improve the maintainability and extensibility of the codebase.