### PR TITLE
Enhance BeanSource registration and support for registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.21         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.21         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.22         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.22         |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanClass;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerGenericBeans;
 import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactoryClasses;
@@ -121,25 +122,119 @@ public enum BeanSource {
     public abstract <T> Set<Class<T>> getBeanTypes(ConfigurableListableBeanFactory beanFactory, Class<T> beanType);
 
     /**
-     * Registers beans into the given {@link ConfigurableListableBeanFactory} based on the specified {@code beanTypes}.
+     * Registers beans into the given {@link BeanDefinitionRegistry} from this source.
      * <p>
-     * For each provided {@code beanType}, this method retrieves the corresponding bean classes from this source
-     * (e.g., Bean Factory, Spring Factories, or Java Service Provider) and registers them as generic beans.
+     * This method discovers bean classes for the specified {@code beanTypes} using this {@link BeanSource},
+     * and registers them as generic beans. The underlying {@link ConfigurableListableBeanFactory} is derived
+     * from the provided registry for type resolution if necessary.
      *
-     * @param beanFactory the {@link ConfigurableListableBeanFactory} to register beans into
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories source
+     * BeanDefinitionRegistry registry = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.SPRING_FACTORIES.registerBeans(
+     *     registry,
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param registry  the {@link BeanDefinitionRegistry} to register beans into
+     * @param beanTypes the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @see #registerBeans(ConfigurableListableBeanFactory, BeanDefinitionRegistry, Class...)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    @Nonnull
+    @Immutable
+    public Map<Class<?>, String> registerBeans(BeanDefinitionRegistry registry, Class<?>... beanTypes) {
+        return registerBeans(asConfigurableListableBeanFactory(registry), registry, beanTypes);
+    }
+
+    /**
+     * Registers beans into the {@link BeanDefinitionRegistry} derived from the given {@link ConfigurableListableBeanFactory}
+     * from this source.
+     * <p>
+     * This method discovers bean classes for the specified {@code beanTypes} using this {@link BeanSource},
+     * and registers them as generic beans. The underlying {@link BeanDefinitionRegistry} is derived
+     * from the provided {@link ConfigurableListableBeanFactory}.
+     *
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories source
+     * ConfigurableListableBeanFactory beanFactory = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.SPRING_FACTORIES.registerBeans(
+     *     beanFactory,
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to use for resolution and to derive the registry
      * @param beanTypes   the target bean types to search for and register
      * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
-     * @see #getBeanTypes(ConfigurableListableBeanFactory, Class)
+     * @see #registerBeans(ConfigurableListableBeanFactory, BeanDefinitionRegistry, Class...)
      * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
      */
     @Nonnull
     @Immutable
     public Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, Class<?>... beanTypes) {
+        return registerBeans(beanFactory, asBeanDefinitionRegistry(beanFactory), beanTypes);
+    }
+
+    /**
+     * Registers beans into the given {@link BeanDefinitionRegistry} from this source.
+     * <p>
+     * This method discovers bean classes for the specified {@code beanTypes} using this {@link BeanSource},
+     * and registers them as generic beans.
+     *
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories source
+     * ConfigurableListableBeanFactory beanFactory = ...;
+     * BeanDefinitionRegistry registry = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.SPRING_FACTORIES.registerBeans(
+     *     beanFactory,
+     *     registry,
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to use for resolution
+     * @param registry    the {@link BeanDefinitionRegistry} to register beans into
+     * @param beanTypes   the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @see #registerBeans(ConfigurableListableBeanFactory, Class...)
+     * @see #registerBeans(BeanDefinitionRegistry, Class...)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    @Nonnull
+    @Immutable
+    public Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                               Class<?>... beanTypes) {
         int length = length(beanTypes);
         if (length == 0) {
             return emptyMap();
         }
-        BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
         Map<Class<?>, String> beanTypesAndNames = registerBeans(beanFactory, registry, beanTypes, length);
         return unmodifiableMap(beanTypesAndNames);
     }
@@ -166,31 +261,133 @@ public enum BeanSource {
     }
 
     /**
-     * Registers beans into the given {@link ConfigurableListableBeanFactory} from the specified {@link BeanSource}s.
+     * Registers beans into the {@link BeanDefinitionRegistry} derived from the given {@link ConfigurableListableBeanFactory}
+     * using the specified {@link BeanSource}s.
      * <p>
      * This method iterates over the provided {@code beanSources}, retrieves the bean classes for each {@code beanType}
      * from each source, and registers them as generic beans. If multiple sources provide beans for the same type,
      * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
      * may override earlier ones if the bean name conflicts).
      *
-     * @param beanFactory the {@link ConfigurableListableBeanFactory} to register beans into
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories and Java Service Provider sources
+     * ConfigurableListableBeanFactory beanFactory = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.registerBeans(
+     *     beanFactory,
+     *     new BeanSource[]{BeanSource.SPRING_FACTORIES, BeanSource.JAVA_SERVICE_PROVIDER},
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to use for resolution and to derive the registry
      * @param beanSources the array of {@link BeanSource}s to use for discovering bean classes
      * @param beanTypes   the target bean types to search for and register
      * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
      * @throws IllegalArgumentException if {@code beanSources} is {@code null} or empty
-     * @see #registerBeans(ConfigurableListableBeanFactory, Class...)
+     * @see #registerBeans(BeanDefinitionRegistry, BeanSource[], Class...)
+     * @see #registerBeans(ConfigurableListableBeanFactory, BeanDefinitionRegistry, BeanSource[], Class...)
      * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
      */
     @Nonnull
     @Immutable
     public static Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanSource[] beanSources, Class<?>... beanTypes) {
+        return registerBeans(beanFactory, asBeanDefinitionRegistry(beanFactory), beanSources, beanTypes);
+    }
+
+    /**
+     * Registers beans into the given {@link BeanDefinitionRegistry} from the specified {@link BeanSource}s.
+     * <p>
+     * This method iterates over the provided {@code beanSources}, retrieves the bean classes for each {@code beanType}
+     * from each source, and registers them as generic beans. If multiple sources provide beans for the same type,
+     * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
+     * may override earlier ones if the bean name conflicts).
+     *
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories and Java Service Provider sources
+     * BeanDefinitionRegistry registry = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.registerBeans(
+     *     registry,
+     *     new BeanSource[]{BeanSource.SPRING_FACTORIES, BeanSource.JAVA_SERVICE_PROVIDER},
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param registry    the {@link BeanDefinitionRegistry} to register beans into
+     * @param beanSources the array of {@link BeanSource}s to use for discovering bean classes
+     * @param beanTypes   the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @throws IllegalArgumentException if {@code beanSources} is {@code null} or empty
+     * @see #registerBeans(ConfigurableListableBeanFactory, BeanSource[], Class...)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    @Nonnull
+    @Immutable
+    public static Map<Class<?>, String> registerBeans(BeanDefinitionRegistry registry, BeanSource[] beanSources, Class<?>... beanTypes) {
+        return registerBeans(asConfigurableListableBeanFactory(registry), registry, beanSources, beanTypes);
+    }
+
+    /**
+     * Registers beans into the given {@link BeanDefinitionRegistry} from the specified {@link BeanSource}s.
+     * <p>
+     * This method iterates over the provided {@code beanSources}, retrieves the bean classes for each {@code beanType}
+     * from each source, and registers them as generic beans. If multiple sources provide beans for the same type,
+     * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
+     * may override earlier ones if the bean name conflicts).
+     *
+     * <h3>Example Usage:</h3>
+     * <pre>{@code
+     * // Register beans from Spring Factories and Java Service Provider sources
+     * ConfigurableListableBeanFactory beanFactory = ...;
+     * BeanDefinitionRegistry registry = ...;
+     *
+     * Map<Class<?>, String> registeredBeans = BeanSource.registerBeans(
+     *     beanFactory,
+     *     registry,
+     *     new BeanSource[]{BeanSource.SPRING_FACTORIES, BeanSource.JAVA_SERVICE_PROVIDER},
+     *     MyService.class,
+     *     AnotherService.class
+     * );
+     *
+     * // The map contains the registered bean classes as keys and their bean names as values
+     * registeredBeans.forEach((beanClass, beanName) -> {
+     *     System.out.println("Registered: " + beanClass.getName() + " with name: " + beanName);
+     * });
+     * }</pre>
+     *
+     * @param beanFactory the {@link ConfigurableListableBeanFactory} to use for resolution and bean class detection
+     * @param registry    the {@link BeanDefinitionRegistry} to register beans into
+     * @param beanSources the array of {@link BeanSource}s to use for discovering bean classes
+     * @param beanTypes   the target bean types to search for and register
+     * @return an unmodifiable {@link Map} where keys are the registered bean classes and values are their corresponding bean names
+     * @throws IllegalArgumentException if {@code beanSources} is {@code null} or empty
+     * @see #registerBeans(ConfigurableListableBeanFactory, BeanSource[], Class...)
+     * @see BeanRegistrar#registerGenericBeans(BeanDefinitionRegistry, Collection)
+     */
+    public static Map<Class<?>, String> registerBeans(ConfigurableListableBeanFactory beanFactory, BeanDefinitionRegistry registry,
+                                                      BeanSource[] beanSources, Class<?>... beanTypes) {
         int length = length(beanTypes);
         if (length == 0) {
             return emptyMap();
         }
         Map<Class<?>, String> beanTypesAndNames = newHashMap(length);
         for (BeanSource beanSource : beanSources) {
-            beanTypesAndNames.putAll(beanSource.registerBeans(beanFactory, beanTypes));
+            beanTypesAndNames.putAll(beanSource.registerBeans(beanFactory, registry, beanTypes));
         }
         return unmodifiableMap(beanTypesAndNames);
     }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
@@ -763,6 +763,42 @@ public abstract class BeanFactoryUtils implements Utils {
         return null;
     }
 
+    /**
+     * Retrieves the {@link BeanDefinition} for the specified bean name from the given {@link BeanDefinitionRegistry}.
+     *
+     * <p>
+     * This method checks if the registry contains a bean definition for the provided name. If it does,
+     * the corresponding {@link BeanDefinition} is returned. Otherwise, this method returns {@code null}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * BeanDefinitionRegistry registry = ...; // Obtain or inject the bean definition registry
+     * String beanName = "myBean";
+     *
+     * BeanDefinition beanDefinition = BeanFactoryUtils.getBeanDefinition(registry, beanName);
+     *
+     * if (beanDefinition != null) {
+     *     // Inspect or modify the bean definition
+     *     System.out.println("Bean class: " + beanDefinition.getBeanClassName());
+     * } else {
+     *     // Handle case where bean definition is not found
+     *     System.out.println("No bean definition found for name: " + beanName);
+     * }
+     * }</pre>
+     *
+     * @param registry  The target bean definition registry to retrieve the bean definition from. Must not be {@code null}.
+     * @param beanName  The name of the bean whose definition is to be retrieved. Must not be {@code null} or empty.
+     * @return The {@link BeanDefinition} if present in the registry; otherwise, {@code null}.
+     */
+    @Nullable
+    public static BeanDefinition getBeanDefinition(BeanDefinitionRegistry registry, String beanName) {
+        if (registry.containsBeanDefinition(beanName)) {
+            return registry.getBeanDefinition(beanName);
+        }
+        return null;
+    }
+
     private static <T> T cast(@Nullable Object beanFactory, Class<T> extendedBeanFactoryType) {
         if (beanFactory == null) {
             return null;

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
@@ -33,6 +33,7 @@ import org.springframework.core.io.support.SpringFactoriesLoader;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -195,7 +196,6 @@ public abstract class BeanRegistrar {
     public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, Class<?> beanType) {
         return registerBeanDefinition(registry, null, beanType);
     }
-
 
     /**
      * Register a {@link BeanDefinition} for the specified bean type with an optional name.
@@ -381,6 +381,71 @@ public abstract class BeanRegistrar {
                                                  Class<?> beanType, Consumer<BeanDefinitionBuilder> builderConsumer) {
         AbstractBeanDefinition beanDefinition = genericBeanDefinition(beanType, builderConsumer);
         return registerBeanDefinition(registry, beanName, beanDefinition);
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} for the specified bean type with the primary flag.
+     * <p>
+     * This method creates a generic bean definition for the provided bean type and sets its primary status.
+     * A unique bean name will be generated automatically based on the bean type. The bean definition is then
+     * registered in the given registry. If the bean is successfully registered, it returns {@code true};
+     * otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register as a primary bean
+     * boolean registered = registerBeanDefinition(registry, MyService.class, true);
+     *
+     * if (registered) {
+     *     System.out.println("Primary bean registered successfully.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanType The class type of the bean to be registered.
+     * @param primary  Whether this bean should be marked as the primary bean.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, Class<?> beanType, boolean primary) {
+        return registerBeanDefinition(registry, null, beanType, primary);
+    }
+
+    /**
+     * Registers a {@link BeanDefinition} for the specified bean type with the primary flag and an optional name.
+     * <p>
+     * This method creates a generic bean definition for the provided bean type and sets its primary status.
+     * If a bean name is provided, it will be used; otherwise, a unique bean name will be generated automatically
+     * based on the bean type. The bean definition is then registered in the given registry. If the bean is
+     * successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Register as a primary bean with auto-generated name
+     * boolean registered = registerBeanDefinition(registry, null, MyService.class, true);
+     *
+     * // Register as a non-primary bean with explicit name
+     * boolean registered = registerBeanDefinition(registry, "mySecondaryService", MyService.class, false);
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully with primary flag.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanName The name to assign to the bean in the registry, or {@code null} to generate a unique name.
+     * @param beanType The class type of the bean to be registered.
+     * @param primary  Whether this bean should be marked as the primary bean.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
+                                                 Class<?> beanType, boolean primary) {
+        return registerBeanDefinition(registry, beanName, beanType, builder -> builder.setPrimary(primary));
     }
 
     /**
@@ -777,7 +842,7 @@ public abstract class BeanRegistrar {
         Map<Class<?>, String> beanTypesAndNames = newFixedHashMap(length);
         for (int i = 0; i < length; i++) {
             Class<?> beanClass = beanClasses[i];
-            Map.Entry<String, Boolean> result = registerGenericBean(registry, beanClass);
+            Entry<String, Boolean> result = registerGenericBean(registry, beanClass);
             String beanName = result.getKey();
             beanTypesAndNames.put(beanClass, beanName);
         }
@@ -808,10 +873,10 @@ public abstract class BeanRegistrar {
      *
      * @param registry  The {@link BeanDefinitionRegistry} where the bean will be registered.
      * @param beanClass The class type of the bean to be registered.
-     * @return An immutable {@link Map.Entry} where the key is the generated bean name and the value is {@code true} if
+     * @return An immutable {@link Entry} where the key is the generated bean name and the value is {@code true} if
      * the bean was successfully registered, or {@code false} if it was already present and overriding is disabled.
      */
-    public static Map.Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass) {
+    public static Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass) {
         return registerGenericBean(registry, beanClass, INSTANCE);
     }
 
@@ -839,10 +904,10 @@ public abstract class BeanRegistrar {
      * @param registry          The {@link BeanDefinitionRegistry} where the bean will be registered.
      * @param beanClass         The class type of the bean to be registered.
      * @param beanNameGenerator The {@link BeanNameGenerator} to use for generating the bean name.
-     * @return An immutable {@link Map.Entry} where the key is the generated bean name and the value is {@code true} if
+     * @return An immutable {@link Entry} where the key is the generated bean name and the value is {@code true} if
      * the bean was successfully registered, or {@code false} if it was already present and overriding is disabled.
      */
-    public static Map.Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass,
+    public static Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass,
                                                                  BeanNameGenerator beanNameGenerator) {
         BeanDefinition beanDefinition = genericBeanDefinition(beanClass);
         String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
@@ -445,7 +445,9 @@ public abstract class BeanRegistrar {
      */
     public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, @Nullable String beanName,
                                                  Class<?> beanType, boolean primary) {
-        return registerBeanDefinition(registry, beanName, beanType, builder -> builder.setPrimary(primary));
+        AbstractBeanDefinition beanDefinition = genericBeanDefinition(beanType);
+        beanDefinition.setPrimary(primary);
+        return registerBeanDefinition(registry, beanName, beanDefinition);
     }
 
     /**
@@ -908,7 +910,7 @@ public abstract class BeanRegistrar {
      * the bean was successfully registered, or {@code false} if it was already present and overriding is disabled.
      */
     public static Entry<String, Boolean> registerGenericBean(BeanDefinitionRegistry registry, Class<?> beanClass,
-                                                                 BeanNameGenerator beanNameGenerator) {
+                                                             BeanNameGenerator beanNameGenerator) {
         BeanDefinition beanDefinition = genericBeanDefinition(beanClass);
         String beanName = beanNameGenerator.generateBeanName(beanDefinition, registry);
         boolean registered = registerBeanDefinition(registry, beanName, beanDefinition);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EnableEventExtension.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EnableEventExtension.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.context.event;
 
+import io.microsphere.spring.beans.BeanSource;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -27,6 +28,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.concurrent.Executor;
 
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -80,4 +84,18 @@ public @interface EnableEventExtension {
      */
     String executorForListener() default NO_EXECUTOR;
 
+    /**
+     * Indicate the sources of beans from which the Spring extension components are collected, such as:
+     * <ul>
+     *  <li>{@link ApplicationEventInterceptor}</li>
+     *  <li>{@link ApplicationListenerInterceptor}</li>
+     * </ul>
+     *
+     * @return the default value is the array of
+     * {@link BeanSource#BEAN_FACTORY}, {@link BeanSource#SPRING_FACTORIES} and {@link BeanSource#JAVA_SERVICE_PROVIDER}
+     * @see BeanSource#BEAN_FACTORY
+     * @see BeanSource#SPRING_FACTORIES
+     * @see BeanSource#JAVA_SERVICE_PROVIDER
+     */
+    BeanSource[] sources() default {BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER};
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionAttributes.java
@@ -19,6 +19,7 @@ package io.microsphere.spring.context.event;
 
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.annotation.Nullable;
+import io.microsphere.spring.beans.BeanSource;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.type.AnnotationMetadata;
@@ -59,5 +60,10 @@ class EventExtensionAttributes extends ResolvablePlaceholderAnnotationAttributes
     @Nonnull
     public String getExecutorForListener() {
         return getString(EXECUTOR_FOR_LISTENER_ATTRIBUTE_NAME);
+    }
+
+    @Nonnull
+    public BeanSource[] getSources() {
+        return (BeanSource[]) get("sources");
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.context.event;
 
 import io.microsphere.logging.Logger;
+import io.microsphere.spring.beans.BeanSource;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -34,6 +35,8 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import static io.microsphere.logging.LoggerFactory.getLogger;
+import static io.microsphere.spring.beans.BeanSource.registerBeans;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanDefinition;
 import static io.microsphere.spring.context.event.EnableEventExtension.NO_EXECUTOR;
 import static io.microsphere.spring.context.event.EventExtensionAttributes.EXECUTOR_FOR_LISTENER_ATTRIBUTE_NAME;
 import static io.microsphere.spring.context.event.EventExtensionAttributes.INTERCEPTED_ATTRIBUTE_NAME;
@@ -89,7 +92,7 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
             return;
         }
 
-        final BeanDefinition existedBeanDefinition = getApplicationEventMulticasterBeanDefinition(beanName, registry);
+        final BeanDefinition existedBeanDefinition = getBeanDefinition(registry, beanName);
 
         final BeanDefinition targetBeanDefinition;
 
@@ -107,6 +110,12 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
             targetBeanDefinition = rebuildApplicationEventMulticasterBeanDefinition(intercepted, existedBeanDefinition, beanName, registry);
         }
 
+        if (intercepted) {
+            BeanSource[] sources = attributes.getSources();
+            registerApplicationEventInterceptors(registry, sources);
+            registerApplicationListenerInterceptors(registry, sources);
+        }
+
         associateExecutorBeanIfRequired(targetBeanDefinition, associatedExecutorBean, executorForListener);
         registry.registerBeanDefinition(beanName, targetBeanDefinition);
     }
@@ -119,10 +128,6 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
             return false;
         }
         return true;
-    }
-
-    BeanDefinition getApplicationEventMulticasterBeanDefinition(String beanName, BeanDefinitionRegistry registry) {
-        return registry.containsBeanDefinition(beanName) ? registry.getBeanDefinition(beanName) : null;
     }
 
     private AbstractBeanDefinition rebuildApplicationEventMulticasterBeanDefinition(boolean intercepted,
@@ -153,6 +158,14 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
         beanDefinition.setAttribute(EXECUTOR_FOR_LISTENER_ATTRIBUTE_NAME, executorForListener);
         beanDefinition.setAttribute(CLASS_NAME_ATTRIBUTE_NAME, metadata.getClassName());
         return beanDefinition;
+    }
+
+    private void registerApplicationEventInterceptors(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, ApplicationEventInterceptor.class);
+    }
+
+    private void registerApplicationListenerInterceptors(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, ApplicationListenerInterceptor.class);
     }
 
     private void associateExecutorBeanIfRequired(BeanDefinition beanDefinition,

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanSourceTest.java
@@ -20,6 +20,7 @@ package io.microsphere.spring.beans;
 import io.microsphere.spring.test.domain.User;
 import org.junit.Test;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +31,7 @@ import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
 import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.BeanSource.values;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
 import static io.microsphere.util.ArrayUtils.ofArray;
 import static java.util.Collections.emptyMap;
@@ -87,6 +89,22 @@ public class BeanSourceTest {
             beanTypesAndNames = registerBeans(beanFactory, values());
             assertSame(emptyMap(), beanTypesAndNames);
         }, User.class);
+
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
+            Map<Class<?>, String> beanTypesAndNames = registerBeans(registry, ofArray(BEAN_FACTORY), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(registry, ofArray(BEAN_FACTORY, SPRING_FACTORIES), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(registry, ofArray(BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER), User.class);
+            assertBeans(beanTypesAndNames);
+
+            beanTypesAndNames = registerBeans(registry, values());
+            assertSame(emptyMap(), beanTypesAndNames);
+        }, User.class);
     }
 
     void assertBeanTypes(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
@@ -100,6 +118,12 @@ public class BeanSourceTest {
             ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
             assertRegisterBeans(beanFactory, beanSource);
         }, User.class);
+
+        testInSpringContainer(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
+            assertRegisterBeans(registry, beanSource);
+        }, User.class);
     }
 
     void assertRegisterBeans(ConfigurableListableBeanFactory beanFactory, BeanSource beanSource) {
@@ -107,6 +131,14 @@ public class BeanSourceTest {
         assertBeans(beanTypesAndNames);
 
         beanTypesAndNames = beanSource.registerBeans(beanFactory);
+        assertSame(emptyMap(), beanTypesAndNames);
+    }
+
+    private void assertRegisterBeans(BeanDefinitionRegistry registry, BeanSource beanSource) {
+        Map<Class<?>, String> beanTypesAndNames = beanSource.registerBeans(registry, User.class);
+        assertBeans(beanTypesAndNames);
+
+        beanTypesAndNames = beanSource.registerBeans(registry);
         assertSame(emptyMap(), beanTypesAndNames);
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/BeanFactoryUtilsTest.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
@@ -304,6 +305,9 @@ public class BeanFactoryUtilsTest {
             ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
             assertNotNull(getBeanDefinition(beanFactory, "baseTestBean"));
             assertNull(getBeanDefinition(beanFactory, "baseTestBean2"));
+            BeanDefinitionRegistry registry = asBeanDefinitionRegistry(beanFactory);
+            assertNotNull(getBeanDefinition(registry, "baseTestBean"));
+            assertNull(getBeanDefinition(registry, "baseTestBean2"));
         }, BaseTestBean.class);
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
@@ -136,6 +136,12 @@ public class BeanRegistrarTest {
     }
 
     @Test
+    public void testRegisterBeanDefinitionWithPrimaryAndNoBeanName() {
+        String beanName = "io.microsphere.spring.test.domain.User#0";
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class, true), true, ROLE_APPLICATION, true, beanName);
+    }
+
+    @Test
     public void testRegisterBeanDefinitionWithBuilder() {
         String beanName = "io.microsphere.spring.test.domain.User#0";
         assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class, builder -> builder.setRole(ROLE_INFRASTRUCTURE)), true, ROLE_INFRASTRUCTURE, false, beanName);

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
@@ -85,24 +85,24 @@ public class BeanRegistrarTest {
 
     @Test
     public void testRegisterInfrastructureBean() {
-        assertBeanDefinitions(() -> registerInfrastructureBean(this.beanFactory, User.class), true, ROLE_INFRASTRUCTURE, "io.microsphere.spring.test.domain.User#0");
-        assertBeanDefinitions(() -> registerInfrastructureBean(this.beanFactory, User.class), true, ROLE_INFRASTRUCTURE, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1");
+        assertBeanDefinitions(() -> registerInfrastructureBean(this.beanFactory, User.class), true, ROLE_INFRASTRUCTURE, false, "io.microsphere.spring.test.domain.User#0");
+        assertBeanDefinitions(() -> registerInfrastructureBean(this.beanFactory, User.class), true, ROLE_INFRASTRUCTURE, false, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1");
     }
 
     @Test
     public void testRegisterBeanDefinition() {
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class), true, ROLE_APPLICATION, "io.microsphere.spring.test.domain.User#0");
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class), true, ROLE_APPLICATION, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1");
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class), true, ROLE_APPLICATION, false, "io.microsphere.spring.test.domain.User#0");
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class), true, ROLE_APPLICATION, false, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1");
 
         String beanName = "user";
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class), true, ROLE_APPLICATION, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1", beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class), true, ROLE_APPLICATION, false, "io.microsphere.spring.test.domain.User#0", "io.microsphere.spring.test.domain.User#1", beanName);
     }
 
     @Test
     public void testRegisterBeanDefinitionWithConstructorArguments() {
         String beanName = "user";
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, "Mercy", 18), true, ROLE_APPLICATION, beanName);
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, "Mercy", 18), false, ROLE_APPLICATION, beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, "Mercy", 18), true, ROLE_APPLICATION, false, beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, "Mercy", 18), false, ROLE_APPLICATION, false, beanName);
         User user = this.beanFactory.getBean(beanName, User.class);
         assertEquals("Mercy", user.getName());
         assertEquals(18, user.getAge());
@@ -115,7 +115,7 @@ public class BeanRegistrarTest {
         AbstractBeanDefinition beanDefinition = genericBeanDefinition(User.class, builder -> {
             builder.setRole(ROLE_APPLICATION);
         });
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, beanDefinition, true), true, ROLE_APPLICATION, beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, beanDefinition, true), true, ROLE_APPLICATION, false, beanName);
 
         assertTrue(registerBeanDefinition(this.beanFactory, beanName, beanDefinition, true));
 
@@ -126,13 +126,19 @@ public class BeanRegistrarTest {
     @Test
     public void testRegisterBeanDefinitionWithRole() {
         String beanName = "user";
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, ROLE_INFRASTRUCTURE), true, ROLE_INFRASTRUCTURE, beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, ROLE_INFRASTRUCTURE), true, ROLE_INFRASTRUCTURE, false, beanName);
+    }
+
+    @Test
+    public void testRegisterBeanDefinitionWithPrimary() {
+        String beanName = "user";
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, beanName, User.class, true), true, ROLE_APPLICATION, true, beanName);
     }
 
     @Test
     public void testRegisterBeanDefinitionWithBuilder() {
         String beanName = "io.microsphere.spring.test.domain.User#0";
-        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class, builder -> builder.setRole(ROLE_INFRASTRUCTURE)), true, ROLE_INFRASTRUCTURE, beanName);
+        assertBeanDefinitions(() -> registerBeanDefinition(this.beanFactory, User.class, builder -> builder.setRole(ROLE_INFRASTRUCTURE)), true, ROLE_INFRASTRUCTURE, false, beanName);
     }
 
     @Test
@@ -219,7 +225,8 @@ public class BeanRegistrarTest {
         return beanName;
     }
 
-    private void assertBeanDefinitions(Supplier<Boolean> booleanSupplier, boolean expectedRegistered, int role, String... expectedBeanNames) {
+    private void assertBeanDefinitions(Supplier<Boolean> booleanSupplier, boolean expectedRegistered, int role,
+                                       boolean primary, String... expectedBeanNames) {
         boolean registered = booleanSupplier.get();
 
         String[] beanNames = this.beanFactory.getBeanNamesForType(User.class);
@@ -229,6 +236,7 @@ public class BeanRegistrarTest {
         for (String beanName : beanNames) {
             BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(beanName);
             assertEquals(role, beanDefinition.getRole());
+            assertEquals(primary, beanDefinition.isPrimary());
         }
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/EventExtensionRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/EventExtensionRegistrarTest.java
@@ -24,17 +24,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.PayloadApplicationEvent;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 
-import java.util.function.Consumer;
-
 import static io.microsphere.logging.test.junit4.LoggingLevelsRule.levels;
-import static io.microsphere.util.ArrayUtils.ofArray;
+import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
+import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
+import static io.microsphere.util.ArrayUtils.combine;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -131,22 +129,18 @@ public class EventExtensionRegistrarTest {
     }
 
     void test(int expected, Class<?>... configClasses) {
+        configClasses = combine(ExecutorConfig.class, configClasses);
+        configClasses = combine(InterceptorConfig.class, configClasses);
+
         MutableInteger i = new MutableInteger(0);
-        testInContext(context -> {
+        testInSpringContainer(context -> {
             context.addApplicationListener(new MutableIntegerApplicationListener());
             context.publishEvent(i);
+            boolean intercepted = i.get() > 1;
+            assertEquals(intercepted, isBeanPresent(context, LoggingApplicationEventInterceptor.class));
+            assertEquals(intercepted, isBeanPresent(context, LoggingApplicationListenerInterceptor.class));
         }, configClasses);
 
         assertEquals(expected, i.get());
-    }
-
-    void testInContext(Consumer<ConfigurableApplicationContext> contextConsumer, Class<?>... configClasses) {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-        Class<?>[] requiredConfigClasses = ofArray(InterceptorConfig.class, ExecutorConfig.class);
-        context.register(requiredConfigClasses);
-        context.register(configClasses);
-        context.refresh();
-        contextConsumer.accept(context);
-        context.close();
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/LoggingApplicationEventInterceptor.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/LoggingApplicationEventInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.event;
+
+import io.microsphere.logging.Logger;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.core.ResolvableType;
+
+import static io.microsphere.logging.LoggerFactory.getLogger;
+
+/**
+ * {@link ApplicationEventInterceptor} for logging
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ApplicationEventInterceptor
+ * @since 1.0.0
+ */
+public class LoggingApplicationEventInterceptor implements ApplicationEventInterceptor {
+
+    private static final Logger logger = getLogger(LoggingApplicationEventInterceptor.class);
+
+    @Override
+    public void intercept(ApplicationEvent event, ResolvableType eventType, ApplicationEventInterceptorChain chain) {
+        logger.info("Before intercept event : {} , type : {}", event, eventType);
+        chain.intercept(event, eventType);
+        logger.info("After intercept event : {} , type : {}", event, eventType);
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/LoggingApplicationListenerInterceptor.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/event/LoggingApplicationListenerInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.event;
+
+import io.microsphere.logging.Logger;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+
+import static io.microsphere.logging.LoggerFactory.getLogger;
+
+/**
+ * {@link ApplicationListenerInterceptor} for logging
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ApplicationListenerInterceptor
+ * @since 1.0.0
+ */
+public class LoggingApplicationListenerInterceptor implements ApplicationListenerInterceptor {
+
+    private static final Logger logger = getLogger(LoggingApplicationListenerInterceptor.class);
+
+    @Override
+    public void intercept(ApplicationListener<?> applicationListener, ApplicationEvent event, ApplicationListenerInterceptorChain chain) {
+        logger.info("Before intercepting application listener: {}", applicationListener);
+        chain.intercept(applicationListener, event);
+        logger.info("After intercepting application listener: {}", applicationListener);
+    }
+}

--- a/microsphere-spring-context/src/test/resources/META-INF/services/io.microsphere.spring.context.event.ApplicationEventInterceptor
+++ b/microsphere-spring-context/src/test/resources/META-INF/services/io.microsphere.spring.context.event.ApplicationEventInterceptor
@@ -1,0 +1,1 @@
+io.microsphere.spring.context.event.LoggingApplicationEventInterceptor

--- a/microsphere-spring-context/src/test/resources/META-INF/spring.factories
+++ b/microsphere-spring-context/src/test/resources/META-INF/spring.factories
@@ -27,3 +27,5 @@ io.microsphere.spring.context.config.AutoRegistrationBean=\
 io.microsphere.spring.context.config.Test1AutoRegistrationBean,\
 io.microsphere.spring.context.config.Test2AutoRegistrationBean
 
+io.microsphere.spring.context.event.ApplicationListenerInterceptor=\
+io.microsphere.spring.context.event.LoggingApplicationListenerInterceptor

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.6</microsphere-java.version>
+        <microsphere-java.version>0.3.7</microsphere-java.version>
         <microsphere-logging.version>0.1.14</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.7</microsphere-java.version>
-        <microsphere-logging.version>0.1.14</microsphere-logging.version>
+        <microsphere-logging.version>0.1.15</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/EnableWebExtension.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/EnableWebExtension.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.web.annotation;
 
+import io.microsphere.spring.beans.BeanSource;
 import io.microsphere.spring.web.event.HandlerMethodArgumentsResolvedEvent;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
 import io.microsphere.spring.web.event.WebEventPublisher;
@@ -24,6 +25,7 @@ import io.microsphere.spring.web.metadata.WebEndpointMappingFactory;
 import io.microsphere.spring.web.metadata.WebEndpointMappingFilter;
 import io.microsphere.spring.web.metadata.WebEndpointMappingRegistry;
 import io.microsphere.spring.web.metadata.WebEndpointMappingResolver;
+import io.microsphere.spring.web.method.support.HandlerMethodAdvice;
 import io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor;
 import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
 import io.microsphere.spring.web.util.RequestContextStrategy;
@@ -37,6 +39,9 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.web.util.RequestContextStrategy.DEFAULT;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.TYPE;
@@ -60,6 +65,9 @@ public @interface EnableWebExtension {
     /**
      * Indicate whether The Spring Web registers the instances of {@link WebEndpointMapping}
      * that source from Spring WebMVC, Spring WebFlux or Classical Servlet.
+     * <p>
+     * If <code>true</code>, {@link WebEndpointMappingResolver}, {@link WebEndpointMappingRegistry},
+     * {@link WebEndpointMappingFactory} and {@link WebEndpointMappingFilter} beans will be initialized.
      *
      * @return <code>true</code> as default
      * @see WebEndpointMapping
@@ -72,6 +80,7 @@ public @interface EnableWebExtension {
 
     /**
      * Indicate whether Spring Web {@link HandlerMethod} should be intercepted.
+     * <p>
      * If <code>true</code>, {@link HandlerMethodArgumentInterceptor} and {@link HandlerMethodInterceptor} beans
      * will be initialized and then be invoked around {@link HandlerMethod} being executed.
      *
@@ -94,6 +103,26 @@ public @interface EnableWebExtension {
      * @see HandlerMethodArgumentsResolvedEvent
      */
     boolean publishEvents() default true;
+
+    /**
+     * Indicate the sources of beans from which the Spring Web extension components are collected, such as:
+     * <ul>
+     *  <li>{@link WebEndpointMappingResolver}</li>
+     *  <li>{@link WebEndpointMappingRegistry}</li>
+     *  <li>{@link WebEndpointMappingFactory}</li>
+     *  <li>{@link WebEndpointMappingFilter}</li>
+     *  <li>{@link HandlerMethodAdvice}</li>
+     *  <li>{@link HandlerMethodArgumentInterceptor}</li>
+     *  <li>{@link HandlerMethodInterceptor}</li>
+     * </ul>
+     *
+     * @return the default value is the array of
+     * {@link BeanSource#BEAN_FACTORY}, {@link BeanSource#SPRING_FACTORIES} and {@link BeanSource#JAVA_SERVICE_PROVIDER}
+     * @see BeanSource#BEAN_FACTORY
+     * @see BeanSource#SPRING_FACTORIES
+     * @see BeanSource#JAVA_SERVICE_PROVIDER
+     */
+    BeanSource[] sources() default {BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER};
 
     /**
      * Indicate where the {@link RequestAttributes} stores.

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
@@ -16,17 +16,31 @@
  */
 package io.microsphere.spring.web.annotation;
 
+import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.event.WebEventPublisher;
+import io.microsphere.spring.web.metadata.CompositeWebEndpointMappingRegistry;
 import io.microsphere.spring.web.metadata.SimpleWebEndpointMappingRegistry;
+import io.microsphere.spring.web.metadata.WebEndpointMappingFactory;
+import io.microsphere.spring.web.metadata.WebEndpointMappingFilter;
 import io.microsphere.spring.web.metadata.WebEndpointMappingRegistrar;
+import io.microsphere.spring.web.metadata.WebEndpointMappingRegistry;
+import io.microsphere.spring.web.metadata.WebEndpointMappingResolver;
 import io.microsphere.spring.web.method.support.DelegatingHandlerMethodAdvice;
+import io.microsphere.spring.web.method.support.HandlerMethodAdvice;
+import io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor;
+import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
+import java.util.Map;
+
+import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
+import static io.microsphere.spring.web.method.support.DelegatingHandlerMethodAdvice.BEAN_NAME;
 
 /**
  * {@link ImportBeanDefinitionRegistrar} for Spring Web Extension
@@ -35,43 +49,83 @@ import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotatio
  * @see EnableWebExtension
  * @since 1.0.0
  */
-public class WebExtensionBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar {
-
-    public static final Class<EnableWebExtension> ANNOTATION_CLASS = EnableWebExtension.class;
-
-    public static final String ANNOTATION_CLASS_NAME = ANNOTATION_CLASS.getName();
+public class WebExtensionBeanDefinitionRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
 
-        AnnotationAttributes attributes = getAttributes(metadata);
+        ResolvablePlaceholderAnnotationAttributes<EnableWebExtension> attributes = getAnnotationAttributes(metadata, EnableWebExtension.class);
 
-        registerWebEndpointMappings(attributes, registry);
+        BeanSource[] sources = (BeanSource[]) attributes.get("sources");
 
-        registerDelegatingHandlerMethodAdvice(attributes, registry);
+        registerWebEndpointMappings(attributes, registry, sources);
+
+        registerInterceptHandlers(attributes, registry, sources);
 
         registerEventPublishingProcessor(attributes, registry);
-
     }
 
-    private AnnotationAttributes getAttributes(AnnotationMetadata metadata) {
-        return getAnnotationAttributes(metadata, ANNOTATION_CLASS_NAME);
-    }
-
-    private void registerWebEndpointMappings(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
+    private void registerWebEndpointMappings(AnnotationAttributes attributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
         boolean registerWebEndpointMappings = attributes.getBoolean("registerWebEndpointMappings");
         if (registerWebEndpointMappings) {
-            registerBeanDefinition(registry, SimpleWebEndpointMappingRegistry.class);
-            registerBeanDefinition(registry, WebEndpointMappingRegistrar.class);
+            registerWebEndpointMappingResolvers(registry, sources);
+            registerWebEndpointMappingRegistries(registry, sources);
+            registerWebEndpointMappingFactories(registry, sources);
+            registerWebEndpointMappingFilters(registry, sources);
+            registerWebEndpointMappingRegistrar(registry);
         }
     }
 
-    private void registerDelegatingHandlerMethodAdvice(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
+    private void registerWebEndpointMappingResolvers(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, WebEndpointMappingResolver.class);
+    }
+
+    private void registerWebEndpointMappingRegistries(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        Map<Class<?>, String> beanTypesAndNames = registerBeans(registry, sources, WebEndpointMappingRegistry.class);
+        if (beanTypesAndNames.isEmpty()) {
+            // If No WebEndpointMappingRegistry bean is registered, register the default SimpleWebEndpointMappingRegistry
+            registerBeanDefinition(registry, SimpleWebEndpointMappingRegistry.class, true);
+        } else {
+            registerBeanDefinition(registry, CompositeWebEndpointMappingRegistry.class, true);
+        }
+    }
+
+    private void registerWebEndpointMappingFactories(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, WebEndpointMappingFactory.class);
+    }
+
+    private void registerWebEndpointMappingFilters(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, WebEndpointMappingFilter.class);
+    }
+
+    private void registerWebEndpointMappingRegistrar(BeanDefinitionRegistry registry) {
+        registerBeanDefinition(registry, WebEndpointMappingRegistrar.class);
+    }
+
+    private void registerInterceptHandlers(AnnotationAttributes attributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
         boolean interceptHandlerMethods = attributes.getBoolean("interceptHandlerMethods");
         if (interceptHandlerMethods) {
-            String beanName = DelegatingHandlerMethodAdvice.BEAN_NAME;
-            registerBeanDefinition(registry, beanName, DelegatingHandlerMethodAdvice.class);
+            registerHandlerMethodAdvices(registry, sources);
+            registerHandlerMethodArgumentInterceptors(registry, sources);
+            registerHandlerMethodInterceptors(registry, sources);
         }
+    }
+
+    private void registerHandlerMethodAdvices(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, HandlerMethodAdvice.class);
+        registerDelegatingHandlerMethodAdvice(registry);
+    }
+
+    private void registerDelegatingHandlerMethodAdvice(BeanDefinitionRegistry registry) {
+        registerBeanDefinition(registry, BEAN_NAME, DelegatingHandlerMethodAdvice.class);
+    }
+
+    private void registerHandlerMethodArgumentInterceptors(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, HandlerMethodArgumentInterceptor.class);
+    }
+
+    private void registerHandlerMethodInterceptors(BeanDefinitionRegistry registry, BeanSource[] sources) {
+        registerBeans(registry, sources, HandlerMethodInterceptor.class);
     }
 
     private void registerEventPublishingProcessor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/CompositeWebEndpointMappingRegistry.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/CompositeWebEndpointMappingRegistry.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.web.metadata;
+
+import org.springframework.beans.factory.SmartInitializingSingleton;
+
+import java.util.Collection;
+import java.util.List;
+
+import static io.microsphere.collection.ListUtils.newLinkedList;
+import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Composite {@link WebEndpointMappingRegistry}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see FilteringWebEndpointMappingRegistry
+ * @see WebEndpointMappingRegistry
+ * @since 1.0.0
+ */
+public class CompositeWebEndpointMappingRegistry extends FilteringWebEndpointMappingRegistry implements SmartInitializingSingleton {
+
+    private List<WebEndpointMappingRegistry> registries = newLinkedList();
+
+    @Override
+    protected boolean doRegister(WebEndpointMapping webEndpointMapping) {
+        boolean registered = false;
+        for (WebEndpointMappingRegistry registry : registries) {
+            registered |= registry.register(webEndpointMapping);
+        }
+        return registered;
+    }
+
+    @Override
+    public Collection<WebEndpointMapping> getWebEndpointMappings() {
+        return this.registries.stream()
+                .flatMap(registry -> registry.getWebEndpointMappings().stream())
+                .collect(toList());
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        List<WebEndpointMappingRegistry> registries = getSortedBeans(this.beanFactory, WebEndpointMappingRegistry.class);
+        for (WebEndpointMappingRegistry registry : registries) {
+            if (registry != this) {
+                this.registries.add(registry);
+            }
+        }
+    }
+}

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistry.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistry.java
@@ -18,11 +18,14 @@ package io.microsphere.spring.web.metadata;
 
 import io.microsphere.filter.Filter;
 import io.microsphere.filter.FilterOperator;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 
 import java.util.List;
 
 import static io.microsphere.filter.FilterOperator.OR;
-import static io.microsphere.lang.function.Streams.filterList;
+import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 import static io.microsphere.util.ArrayUtils.asArray;
 
 /**
@@ -33,32 +36,30 @@ import static io.microsphere.util.ArrayUtils.asArray;
  * @see WebEndpointMappingFilter
  * @since 1.0.0
  */
-public abstract class FilteringWebEndpointMappingRegistry implements WebEndpointMappingRegistry {
+public abstract class FilteringWebEndpointMappingRegistry implements WebEndpointMappingRegistry, BeanFactoryAware {
 
     protected static final Filter<WebEndpointMapping> DEFAULT_FILTER = e -> true;
 
     protected static final FilterOperator DEFAULT_FILTER_OPERATOR = OR;
 
-    private Filter<WebEndpointMapping> filter;
+    protected Filter<WebEndpointMapping> filter;
 
-    private FilterOperator filterOperator;
+    protected FilterOperator filterOperator;
+
+    protected BeanFactory beanFactory;
+
+    @Override
+    public final boolean register(WebEndpointMapping webEndpointMapping) {
+        Filter<WebEndpointMapping> filter = getFilter();
+        if (filter.accept(webEndpointMapping)) {
+            return doRegister(webEndpointMapping);
+        }
+        return false;
+    }
 
     @Override
     public final int register(Iterable<WebEndpointMapping> webEndpointMappings) {
-        List<WebEndpointMapping> filteredWebEndpointMappings = filterWebEndpointMappings(webEndpointMappings);
-        int size = filteredWebEndpointMappings.size();
-        int count = size;
-        for (int i = 0; i < size; i++) {
-            WebEndpointMapping filteredWebEndpointMapping = filteredWebEndpointMappings.get(i);
-            if (!register(filteredWebEndpointMapping)) {
-                count--;
-            }
-        }
-        return count;
-    }
-
-    protected List<WebEndpointMapping> filterWebEndpointMappings(Iterable<WebEndpointMapping> webEndpointMappings) {
-        return filterList(webEndpointMappings, getFilter()::accept);
+        return WebEndpointMappingRegistry.super.register(webEndpointMappings);
     }
 
     public void setFilterOperator(FilterOperator filterOperator) {
@@ -86,4 +87,21 @@ public abstract class FilteringWebEndpointMappingRegistry implements WebEndpoint
         }
         return filterOperator;
     }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+        List<WebEndpointMappingFilter> filters = getSortedBeans(beanFactory, WebEndpointMappingFilter.class);
+        this.setWebEndpointMappingFilters(filters);
+    }
+
+    /**
+     * Registers the given {@link WebEndpointMapping} if it passes the filter.
+     * <p>
+     * Subclasses should implement this method to provide the actual registration logic.
+     *
+     * @param webEndpointMapping the {@link WebEndpointMapping} to register
+     * @return {@code true} if the mapping was registered successfully, {@code false} otherwise
+     */
+    protected abstract boolean doRegister(WebEndpointMapping webEndpointMapping);
 }

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistry.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistry.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.web.metadata;
 
+import io.microsphere.annotation.Nonnull;
 import io.microsphere.filter.Filter;
 import io.microsphere.filter.FilterOperator;
 import org.springframework.beans.BeansException;
@@ -74,6 +75,7 @@ public abstract class FilteringWebEndpointMappingRegistry implements WebEndpoint
         filter = getFilterOperator().createFilter(filters);
     }
 
+    @Nonnull
     public Filter<WebEndpointMapping> getFilter() {
         if (filter == null) {
             return DEFAULT_FILTER;
@@ -81,6 +83,7 @@ public abstract class FilteringWebEndpointMappingRegistry implements WebEndpoint
         return filter;
     }
 
+    @Nonnull
     public FilterOperator getFilterOperator() {
         if (filterOperator == null) {
             return DEFAULT_FILTER_OPERATOR;

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/SimpleWebEndpointMappingRegistry.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/metadata/SimpleWebEndpointMappingRegistry.java
@@ -33,7 +33,7 @@ public class SimpleWebEndpointMappingRegistry extends FilteringWebEndpointMappin
     private final Map<Integer, WebEndpointMapping> repository = newHashMap(256);
 
     @Override
-    public boolean register(WebEndpointMapping webEndpointMapping) {
+    protected boolean doRegister(WebEndpointMapping webEndpointMapping) {
         return repository.put(webEndpointMapping.getId(), webEndpointMapping) == null;
     }
 

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrarTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrarTest.java
@@ -21,6 +21,7 @@ import io.microsphere.spring.web.event.WebEventPublisher;
 import io.microsphere.spring.web.metadata.SimpleWebEndpointMappingRegistry;
 import io.microsphere.spring.web.method.support.DelegatingHandlerMethodAdvice;
 import org.junit.Test;
+import org.springframework.context.annotation.Import;
 
 import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
 import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
@@ -49,6 +50,7 @@ public class WebExtensionBeanDefinitionRegistrarTest {
     }
 
     @EnableWebExtension(publishEvents = false)
+    @Import(SimpleWebEndpointMappingRegistry.class)
     static class DisablePublishEventConfig {
     }
 

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/CompositeWebEndpointMappingRegistryTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/CompositeWebEndpointMappingRegistryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.web.metadata;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static io.microsphere.spring.test.util.SpringTestUtils.testInSpringContainer;
+import static io.microsphere.spring.web.metadata.WebEndpointMapping.servlet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link CompositeWebEndpointMappingRegistry} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see CompositeWebEndpointMappingRegistry
+ * @since 1.0.0
+ */
+public class CompositeWebEndpointMappingRegistryTest {
+
+    private WebEndpointMapping webEndpointMapping;
+
+    @Before
+    public void setUp() {
+        this.webEndpointMapping = servlet()
+                .patterns("/users/**")
+                .methods("GET")
+                .endpoint(this)
+                .build();
+    }
+
+    @Test
+    public void test() {
+        testInSpringContainer(context -> {
+            CompositeWebEndpointMappingRegistry registry = context.getBean(CompositeWebEndpointMappingRegistry.class);
+            assertTrue(registry.register(webEndpointMapping));
+            Collection<WebEndpointMapping> webEndpointMappings = registry.getWebEndpointMappings();
+            assertEquals(1, webEndpointMappings.size());
+            assertTrue(webEndpointMappings.contains(webEndpointMapping));
+        }, CompositeWebEndpointMappingRegistry.class, SimpleWebEndpointMappingRegistry.class);
+    }
+
+    @Test
+    public void testOnNoDelegatingWebEndpointMappingRegistry() {
+        testInSpringContainer(context -> {
+            CompositeWebEndpointMappingRegistry registry = context.getBean(CompositeWebEndpointMappingRegistry.class);
+            assertFalse(registry.register(webEndpointMapping));
+            assertTrue(registry.getWebEndpointMappings().isEmpty());
+        }, CompositeWebEndpointMappingRegistry.class);
+    }
+}

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistryTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistryTest.java
@@ -102,6 +102,13 @@ public class FilteringWebEndpointMappingRegistryTest {
     }
 
     @Test
+    public void testSetWebEndpointMappingFiltersOnDeny() {
+        this.registry.setWebEndpointMappingFilters(asList(e -> false));
+        assertEquals(0, this.registry.register(this.webEndpointMappings));
+        assertNotNull(this.registry.getFilter());
+    }
+
+    @Test
     public void testGetFilter() {
         Filter<WebEndpointMapping> filter = this.registry.getFilter();
         assertNotNull(filter);

--- a/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistryTest.java
+++ b/microsphere-spring-web/src/test/java/io/microsphere/spring/web/metadata/FilteringWebEndpointMappingRegistryTest.java
@@ -62,7 +62,7 @@ public class FilteringWebEndpointMappingRegistryTest {
         }
 
         @Override
-        public boolean register(WebEndpointMapping webEndpointMapping) {
+        protected boolean doRegister(WebEndpointMapping webEndpointMapping) {
             return result;
         }
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/EnableWebFluxExtension.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/EnableWebFluxExtension.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.webflux.annotation;
 
+import io.microsphere.spring.beans.BeanSource;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.event.HandlerMethodArgumentsResolvedEvent;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
@@ -25,6 +26,7 @@ import io.microsphere.spring.web.metadata.WebEndpointMappingFactory;
 import io.microsphere.spring.web.metadata.WebEndpointMappingFilter;
 import io.microsphere.spring.web.metadata.WebEndpointMappingRegistry;
 import io.microsphere.spring.web.metadata.WebEndpointMappingResolver;
+import io.microsphere.spring.web.method.support.HandlerMethodAdvice;
 import io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor;
 import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
 import io.microsphere.spring.web.util.RequestAttributesUtils;
@@ -49,6 +51,9 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.web.util.RequestContextStrategy.DEFAULT;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -113,6 +118,27 @@ public @interface EnableWebFluxExtension {
      */
     @AliasFor(annotation = EnableWebExtension.class)
     boolean publishEvents() default true;
+
+    /**
+     * Indicate the sources of beans from which the Spring Web extension components are collected, such as:
+     * <ul>
+     *  <li>{@link WebEndpointMappingResolver}</li>
+     *  <li>{@link WebEndpointMappingRegistry}</li>
+     *  <li>{@link WebEndpointMappingFactory}</li>
+     *  <li>{@link WebEndpointMappingFilter}</li>
+     *  <li>{@link HandlerMethodAdvice}</li>
+     *  <li>{@link HandlerMethodArgumentInterceptor}</li>
+     *  <li>{@link HandlerMethodInterceptor}</li>
+     * </ul>
+     *
+     * @return the default value is the array of
+     * {@link BeanSource#BEAN_FACTORY}, {@link BeanSource#SPRING_FACTORIES} and {@link BeanSource#JAVA_SERVICE_PROVIDER}
+     * @see BeanSource#BEAN_FACTORY
+     * @see BeanSource#SPRING_FACTORIES
+     * @see BeanSource#JAVA_SERVICE_PROVIDER
+     */
+    @AliasFor(annotation = EnableWebExtension.class)
+    BeanSource[] sources() default {BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER};
 
     /**
      * Indicate where the {@link RequestAttributes} stores.

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.webmvc.annotation;
 
+import io.microsphere.spring.beans.BeanSource;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.event.HandlerMethodArgumentsResolvedEvent;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
@@ -25,6 +26,7 @@ import io.microsphere.spring.web.metadata.WebEndpointMappingFactory;
 import io.microsphere.spring.web.metadata.WebEndpointMappingFilter;
 import io.microsphere.spring.web.metadata.WebEndpointMappingRegistry;
 import io.microsphere.spring.web.metadata.WebEndpointMappingResolver;
+import io.microsphere.spring.web.method.support.HandlerMethodAdvice;
 import io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor;
 import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
 import io.microsphere.spring.web.util.RequestAttributesUtils;
@@ -32,6 +34,7 @@ import io.microsphere.spring.web.util.RequestContextStrategy;
 import io.microsphere.spring.webmvc.advice.StoringRequestBodyArgumentAdvice;
 import io.microsphere.spring.webmvc.handler.ReversedProxyHandlerMapping;
 import io.microsphere.spring.webmvc.util.WebMvcUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.core.MethodParameter;
@@ -49,12 +52,14 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.BeanSource.JAVA_SERVICE_PROVIDER;
+import static io.microsphere.spring.beans.BeanSource.SPRING_FACTORIES;
 import static io.microsphere.spring.web.util.RequestContextStrategy.DEFAULT;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -155,6 +160,27 @@ public @interface EnableWebMvcExtension {
      * @see InterceptorRegistry
      */
     Class<? extends HandlerInterceptor>[] handlerInterceptors() default {};
+
+    /**
+     * Indicate the sources of beans from which the Spring Web extension components are collected, such as:
+     * <ul>
+     *  <li>{@link WebEndpointMappingResolver}</li>
+     *  <li>{@link WebEndpointMappingRegistry}</li>
+     *  <li>{@link WebEndpointMappingFactory}</li>
+     *  <li>{@link WebEndpointMappingFilter}</li>
+     *  <li>{@link HandlerMethodAdvice}</li>
+     *  <li>{@link HandlerMethodArgumentInterceptor}</li>
+     *  <li>{@link HandlerMethodInterceptor}</li>
+     * </ul>
+     *
+     * @return the default value is the array of
+     * {@link BeanSource#BEAN_FACTORY}, {@link BeanSource#SPRING_FACTORIES} and {@link BeanSource#JAVA_SERVICE_PROVIDER}
+     * @see BeanSource#BEAN_FACTORY
+     * @see BeanSource#SPRING_FACTORIES
+     * @see BeanSource#JAVA_SERVICE_PROVIDER
+     */
+    @AliasFor(annotation = EnableWebExtension.class)
+    BeanSource[] sources() default {BEAN_FACTORY, SPRING_FACTORIES, JAVA_SERVICE_PROVIDER};
 
     /**
      * Indicate that {@link RequestAttributes} stores the {@link MethodParameter argument} of {@link HandlerMethod} that annotated {@link RequestBody}

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
@@ -34,7 +34,6 @@ import io.microsphere.spring.web.util.RequestContextStrategy;
 import io.microsphere.spring.webmvc.advice.StoringRequestBodyArgumentAdvice;
 import io.microsphere.spring.webmvc.handler.ReversedProxyHandlerMapping;
 import io.microsphere.spring.webmvc.util.WebMvcUtils;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.core.MethodParameter;
@@ -52,6 +51,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -66,7 +66,7 @@ public class WebMvcExtensionBeanDefinitionRegistrar implements ImportBeanDefinit
 
         AnnotationAttributes attributes = getAttributes(metadata);
 
-        registerWebEndpointMappingRegistrar(attributes, registry);
+        registerWebEndpointMappingResolvers(attributes, registry);
 
         registerInterceptingHandlerMethodProcessor(attributes, registry);
 
@@ -79,7 +79,7 @@ public class WebMvcExtensionBeanDefinitionRegistrar implements ImportBeanDefinit
         registerReversedProxyHandlerMapping(attributes, registry);
     }
 
-    private void registerWebEndpointMappingRegistrar(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
+    private void registerWebEndpointMappingResolvers(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
         boolean registerWebEndpointMappings = attributes.getBoolean("registerWebEndpointMappings");
         if (registerWebEndpointMappings) {
             registerBeanDefinition(registry, ServletWebEndpointMappingResolver.class);

--- a/microsphere-spring-webmvc/src/main/resources/META-INF/spring.factories
+++ b/microsphere-spring-webmvc/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,2 @@
-io.microsphere.spring.web.metadata.WebEndpointMappingFactory=\
-io.microsphere.spring.webmvc.metadata.HandlerMetadataWebEndpointMappingFactory,\
-io.microsphere.spring.webmvc.metadata.RequestMappingMetadataWebEndpointMappingFactory
-
 io.microsphere.spring.web.util.SpringWebHelper=\
 io.microsphere.spring.webmvc.util.SpringWebMvcHelper

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request introduces several enhancements and new utility methods for bean registration and lookup in the Microsphere Spring Context module. The main focus is on expanding the flexibility of the `BeanSource` and `BeanRegistrar` APIs, providing overloaded methods for registering beans from various sources, and improving documentation and usability. Additionally, a new utility method for retrieving bean definitions by name is added.

The most important changes are:

### Bean registration API enhancements

* Added overloaded `registerBeans` methods to `BeanSource` to support registration into both `BeanDefinitionRegistry` and `ConfigurableListableBeanFactory`, and to allow specifying multiple `BeanSource` instances for composite registration. These methods are thoroughly documented with usage examples. [[1]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdL124-L142) [[2]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdL169-R390)
* Updated internal registration logic to consistently use helper methods (`asConfigurableListableBeanFactory`, `asBeanDefinitionRegistry`) for type conversion and to ensure correct bean registration flow. [[1]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdR36) [[2]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdL124-L142) [[3]](diffhunk://#diff-9f8790491b782a9a7daee5b501b7d8f4225dd5d4128682bd36753f2617273acdL169-R390)

### Bean definition utilities

* Added `getBeanDefinition(BeanDefinitionRegistry, String)` to `BeanFactoryUtils`, enabling direct retrieval of a bean definition by name from a registry. This method is documented with example usage.

### BeanRegistrar improvements

* Introduced overloaded `registerBeanDefinition` methods in `BeanRegistrar` to support bean registration with a `primary` flag, and with or without explicit bean names. These methods provide more control over bean registration and are documented with examples.
* Improved type usage in `registerGenericBeans` and `registerGenericBean` to use `Map.Entry` for return values, and updated variable naming for clarity. [[1]](diffhunk://#diff-4348ba060557e8085ac41f046e7daca7ee0f9e3b5d44fcf67baae1a0108606d6L780-R847) [[2]](diffhunk://#diff-4348ba060557e8085ac41f046e7daca7ee0f9e3b5d44fcf67baae1a0108606d6L811-R881)

These changes improve the flexibility, clarity, and usability of bean registration and lookup in the framework.