### PR TITLE
Refactor AutoRegistrationBean loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.22         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.22         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.23         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.23         |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -20,7 +20,6 @@ package io.microsphere.spring.context.annotation;
 import io.microsphere.spring.context.config.AutoRegistrationBean;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.io.support.SpringFactoriesLoader;
@@ -33,8 +32,7 @@ import static io.microsphere.spring.beans.factory.support.BeanRegistrar.register
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
-import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactories;
-
+import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 /**
  * {@link ImportSelector} class for {@link EnableAutoRegistrationBean}
  *
@@ -57,8 +55,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
             return;
         }
 
-        ConfigurableApplicationContext context = getApplicationContext();
-        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(context, AutoRegistrationBean.class);
+        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class,super.classLoader);
         registerAutoRegisteredBeans(autoRegistrationBeans, registry);
     }
 

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.7</microsphere-java.version>
-        <microsphere-logging.version>0.1.16</microsphere-logging.version>
+        <microsphere-logging.version>0.1.15</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.7</microsphere-java.version>
-        <microsphere-logging.version>0.1.15</microsphere-logging.version>
+        <microsphere-logging.version>0.1.16</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>


### PR DESCRIPTION
This pull request primarily updates dependencies and refines how Spring factories are loaded in the `microsphere-spring-context` module. The most important changes include updating the latest version numbers in documentation and simplifying the usage of Spring's `loadFactories` utility.

**Documentation updates:**

* Updated the latest version numbers for both `main` and `1.x` branches in the `README.md` to reflect the new releases (`0.2.23` and `0.1.23`).

**Codebase simplification and modernization:**

* Replaced a custom utility method with Spring's built-in `loadFactories` method for loading `AutoRegistrationBean` factories in `AutoRegistrationBeanRegistrar.java`. [[1]](diffhunk://#diff-adba92a95c47e84412f2d5ec5398e4017e04b81e16ceeec270552f08afad81afL36-R35) [[2]](diffhunk://#diff-adba92a95c47e84412f2d5ec5398e4017e04b81e16ceeec270552f08afad81afL60-R58)
* Removed an unused import of `ConfigurableApplicationContext` from `AutoRegistrationBeanRegistrar.java`.