### PR TITLE
Enhance annotation handling and configuration strategies

### DIFF
--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanUtils.java
@@ -608,6 +608,37 @@ public abstract class BeanUtils implements Utils {
     }
 
     /**
+     * Initialize the given bean instance by invoking its standard Spring lifecycle interfaces.
+     *
+     * <p>This method triggers the invocation of various {@link Aware} interfaces and the
+     * {@link InitializingBean#afterPropertiesSet()} method if the bean implements them.
+     * It effectively simulates the initialization phase of a Spring bean within the provided
+     * {@link ApplicationContext}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * MyBean myBean = new MyBean();
+     * ApplicationContext context = ...; // Obtain or create an ApplicationContext
+     * BeanUtils.initializeBean(myBean, context);
+     * }</pre>
+     *
+     * <h3>Behavior</h3>
+     * <ul>
+     *     <li>If the bean is {@code null}, no action is taken.</li>
+     *     <li>If the context is {@code null}, only basic factory-aware interfaces might be invoked depending on implementation details, but typically context-aware interfaces are skipped.</li>
+     *     <li>The method delegates to {@link #invokeBeanInterfaces(Object, ApplicationContext)} to perform the actual interface invocations.</li>
+     * </ul>
+     *
+     * @param bean    the bean instance to initialize, may be {@code null}
+     * @param context the {@link ApplicationContext} to use for initialization, may be {@code null}
+     * @see #invokeBeanInterfaces(Object, ApplicationContext)
+     */
+    public static void initializeBean(@Nullable Object bean, @Nullable ApplicationContext context) {
+        invokeBeanInterfaces(bean, context);
+    }
+
+    /**
      * Invokes the standard Spring bean lifecycle interfaces in a specific order for the given bean and application context.
      *
      * <p>This method delegates to {@link #invokeBeanInterfaces(Object, ConfigurableApplicationContext)} after converting

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
@@ -787,8 +787,8 @@ public abstract class BeanFactoryUtils implements Utils {
      * }
      * }</pre>
      *
-     * @param registry  The target bean definition registry to retrieve the bean definition from. Must not be {@code null}.
-     * @param beanName  The name of the bean whose definition is to be retrieved. Must not be {@code null} or empty.
+     * @param registry The target bean definition registry to retrieve the bean definition from. Must not be {@code null}.
+     * @param beanName The name of the bean whose definition is to be retrieved. Must not be {@code null} or empty.
      * @return The {@link BeanDefinition} if present in the registry; otherwise, {@code null}.
      */
     @Nullable

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
@@ -102,7 +102,7 @@ class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCa
             }
             return;
         }
-        Properties properties = loadProperties(propertiesValue);
+        Properties properties = loadProperties(propertiesValue, super.environment);
         for (String propertyName : properties.stringPropertyNames()) {
             String propertyValue = properties.getProperty(propertyName);
             Object oldPropertyValue = defaultProperties.put(propertyName, propertyValue);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/constants/PropertyConstants.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/constants/PropertyConstants.java
@@ -33,6 +33,11 @@ public interface PropertyConstants {
     String MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "spring.";
 
     /**
+     * The property name prefix of the configuration property prefix : "microsphere.spring.prefix."
+     */
+    String PREFIX_PROPERTY_NAME_PREFIX = MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX + "prefix.";
+
+    /**
      * The property name prefix of beans : "microsphere.spring.beans."
      */
     String BEANS_PROPERTY_NAME_PREFIX = MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX + "beans.";

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -33,6 +33,7 @@ import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REG
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
+
 /**
  * {@link ImportSelector} class for {@link EnableAutoRegistrationBean}
  *
@@ -55,7 +56,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
             return;
         }
 
-        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class,super.classLoader);
+        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class, super.classLoader);
         registerAutoRegisteredBeans(autoRegistrationBeans, registry);
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
@@ -38,6 +38,7 @@ import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
@@ -47,14 +48,17 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import static io.microsphere.logging.LoggerFactory.getLogger;
+import static io.microsphere.spring.beans.BeanUtils.initializeBean;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBean;
+import static io.microsphere.spring.core.annotation.AnnotationUtils.ofAnnotationAttributes;
 import static io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes.of;
 import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.StringUtils.EMPTY_STRING_ARRAY;
 import static java.lang.Integer.toHexString;
+import static org.springframework.beans.BeanUtils.instantiateClass;
 
 /**
  * The {@link Import @Import} candidate is an instance of {@link org.springframework.context.annotation.ImportSelector} or {@link ImportBeanDefinitionRegistrar}
@@ -271,7 +275,51 @@ public abstract class BeanCapableImportCandidate implements BeanClassLoaderAware
     protected <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> getAnnotationAttributes(AnnotationMetadata metadata, Class<A> annotationType) {
         String annotationClassName = annotationType.getName();
         Map<String, Object> annotationAttributes = metadata.getAnnotationAttributes(annotationClassName);
-        return of(annotationAttributes, annotationType, getEnvironment());
+        AnnotationAttributes overriddenAnnotationAttributes = getOverriddenAnnotationAttributes(annotationAttributes, annotationType, metadata);
+        return of(overriddenAnnotationAttributes, annotationType, getEnvironment());
+    }
+
+    /**
+     * Gets the overridden {@link AnnotationAttributes} for the specified annotation type.
+     * <p>
+     * If the annotation is meta-annotated with {@link OverrideAnnotationAttributes}, this method
+     * instantiates the configured {@link OverrideAnnotationAttributesStrategy}, initializes it as a Spring bean,
+     * and executes the strategy to override the original attributes. Otherwise, it returns the original attributes.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Define a custom annotation with an override strategy
+     * @OverrideAnnotationAttributes(strategy = MyCustomStrategy.class)
+     * @Import(MyImportRegistrar.class)
+     * public @interface MyCustomImport {
+     *     String value() default "";
+     * }
+     *
+     * // In your ImportSelector or ImportBeanDefinitionRegistrar implementation:
+     * public class MyImportRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
+     *     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+     *          // ...
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param annotationAttributes the original annotation attributes map, may be null
+     * @param annotationType       the annotation type class
+     * @param metadata             the annotation metadata of the importing class
+     * @return the overridden {@link AnnotationAttributes}, or the original attributes if no override strategy is defined
+     */
+    protected AnnotationAttributes getOverriddenAnnotationAttributes(Map<String, Object> annotationAttributes,
+                                                                     Class<? extends Annotation> annotationType,
+                                                                     AnnotationMetadata metadata) {
+        OverrideAnnotationAttributes overrideAnnotationAttributes = annotationType.getAnnotation(OverrideAnnotationAttributes.class);
+        AnnotationAttributes originalAttributes = ofAnnotationAttributes(annotationAttributes);
+        if (overrideAnnotationAttributes == null) {
+            return originalAttributes;
+        }
+        Class<? extends OverrideAnnotationAttributesStrategy> strategyClass = overrideAnnotationAttributes.strategy();
+        OverrideAnnotationAttributesStrategy strategy = instantiateClass(strategyClass);
+        initializeBean(strategy, this.applicationContext);
+        return strategy.override(originalAttributes, annotationType, metadata);
     }
 
     private void assertImportCandidate() {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
@@ -93,6 +93,7 @@ import static org.springframework.beans.BeanUtils.instantiateClass;
  * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
+ * @see OverrideAnnotationAttributes
  * @see AbstractAutowireCapableBeanFactory#populateBean(String, RootBeanDefinition, BeanWrapper)
  * @see AutowireCapableBeanFactory#initializeBean(Object, String)
  * @see ConfigurableBeanFactory#destroyBean(String, Object)

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.logging.Logger;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
+import static io.microsphere.logging.LoggerFactory.getLogger;
+import static io.microsphere.reflect.MethodUtils.findMethod;
+import static io.microsphere.spring.constants.PropertyConstants.PREFIX_PROPERTY_NAME_PREFIX;
+import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
+import static io.microsphere.spring.core.env.EnvironmentUtils.getConversionService;
+import static io.microsphere.spring.core.env.PropertySourcesUtils.getSubProperties;
+import static io.microsphere.spring.core.env.PropertySourcesUtils.normalizePrefix;
+
+/**
+ * The implementation of {@link OverrideAnnotationAttributesStrategy} based on the configuration properties.
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see OverrideAnnotationAttributesStrategy
+ * @since 1.0.0
+ */
+public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implements OverrideAnnotationAttributesStrategy,
+        EnvironmentAware {
+
+    private static final Logger logger = getLogger(ConfigurationPropertyOverrideAnnotationAttributesStrategy.class);
+
+    private ConfigurableEnvironment environment;
+
+    @Override
+    public AnnotationAttributes override(Class<? extends Annotation> annotationType, AnnotationAttributes originalAttributes,
+                                         AnnotationMetadata annotationMetadata) {
+        Map<String, Object> configurationProperties = getConfigurationProperties(annotationType);
+        if (configurationProperties.isEmpty()) {
+            return originalAttributes;
+        }
+        ConversionService conversionService = getConversionService(this.environment);
+        AnnotationAttributes newAttributes = new AnnotationAttributes(originalAttributes.size());
+        for (Entry<String, Object> entry : originalAttributes.entrySet()) {
+            String attributeName = entry.getKey();
+            Object originalAttributeValue = entry.getValue();
+            Object configurationPropertyValue = configurationProperties.get(attributeName);
+            String propertyName = getPropertyName(annotationType, attributeName);
+            if (configurationPropertyValue == null) {
+                logger.trace("The configuration property[name : '{}'] is not found, use the original property value : {}",
+                        propertyName, originalAttributeValue);
+                newAttributes.put(attributeName, originalAttributeValue);
+                continue;
+            }
+            Method attributeMethod = findMethod(annotationType, attributeName);
+            Class<?> attributeType = attributeMethod.getReturnType();
+            if (conversionService.canConvert(configurationPropertyValue.getClass(), attributeType)) {
+                Object newPropertyValue = conversionService.convert(configurationPropertyValue, attributeType);
+                newAttributes.put(attributeName, newPropertyValue);
+                logger.info("The configuration property[name : '{}' , value : '{}'] is converted to the attribute[value : {} , type : '{}']",
+                        propertyName, configurationPropertyValue, newPropertyValue, attributeType);
+            } else {
+                newAttributes.put(attributeName, originalAttributeValue);
+                logger.warn("The configuration property[name : '{}' , value : '{}'] cannot be converted to the attribute type : {}",
+                        propertyName, configurationPropertyValue, attributeType);
+            }
+        }
+        return newAttributes;
+    }
+
+    Map<String, Object> getConfigurationProperties(Class<? extends Annotation> annotationType) {
+        String propertyNamePrefix = getPropertyNamePrefix(annotationType);
+        return getSubProperties(this.environment, propertyNamePrefix);
+    }
+
+    String getPropertyName(Class<? extends Annotation> annotationType, String attributeName) {
+        return getPropertyNamePrefix(annotationType) + attributeName;
+    }
+
+    String getPropertyNamePrefix(Class<? extends Annotation> annotationType) {
+        String prefixPropertyName = getPrefixPropertyName(annotationType);
+        String propertyNamePrefix = environment.getProperty(prefixPropertyName, String.class, getDefaultPropertyNamePrefix(annotationType));
+        return normalizePrefix(propertyNamePrefix);
+    }
+
+    static String getPrefixPropertyName(Class<? extends Annotation> annotationType) {
+        return PREFIX_PROPERTY_NAME_PREFIX + annotationType.getName();
+    }
+
+    static String getDefaultPropertyNamePrefix(Class<? extends Annotation> annotationType) {
+        return PREFIX_PROPERTY_NAME_PREFIX + annotationType.getSimpleName() + DOT_CHAR;
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = asConfigurableEnvironment(environment);
+    }
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
@@ -129,7 +129,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implement
         Map<String, Object> configurationProperties = getConfigurationProperties(annotationType);
         if (configurationProperties.isEmpty()) {
             String propertyNamePrefix = getPropertyNamePrefix(annotationType);
-            logger.warn("No configuration properties found for annotation : {}", annotationType);
+            logger.warn("No configuration properties[prefix : '{}'] found for annotation : {}", propertyNamePrefix, annotationType);
             return originalAttributes;
         }
         ConversionService conversionService = getConversionService(this.environment);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
@@ -17,6 +17,7 @@
 
 package io.microsphere.spring.context.annotation;
 
+import io.microsphere.annotation.Nonnull;
 import io.microsphere.logging.Logger;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -40,10 +41,66 @@ import static io.microsphere.spring.core.env.PropertySourcesUtils.getSubProperti
 import static io.microsphere.spring.core.env.PropertySourcesUtils.normalizePrefix;
 
 /**
- * The implementation of {@link OverrideAnnotationAttributesStrategy} based on the configuration properties.
+ * A strategy implementation of {@link OverrideAnnotationAttributesStrategy} that overrides annotation attributes
+ * with values from Spring Environment configuration properties.
+ * <p>
+ * This strategy allows externalizing annotation attribute values into configuration properties (e.g., in {@code application.properties}
+ * or {@code application.yml}). It maps annotation attributes to property keys using a configurable prefix.
+ *
+ * <h3>Property Mapping Logic</h3>
+ * <ol>
+ *     <li><strong>Prefix Determination:</strong> The property prefix is determined by:
+ *         <ul>
+ *             <li>Checking for a custom prefix defined by the property key:
+ *                 {@code microsphere.spring.prefix.<AnnotationClassName>} (e.g., {@code microsphere.spring.prefix.org.springframework.context.annotation.PropertySource})
+ *             </li>
+ *             <li>Falling back to the default prefix:
+ *                 {@code microsphere.spring.prefix.<AnnotationSimpleName>.} (e.g., {@code microsphere.spring.prefix.PropertySource.})
+ *             </li>
+ *         </ul>
+ *     </li>
+ *     <li><strong>Attribute Mapping:</strong> Each annotation attribute name is appended to the resolved prefix to form the full property key.
+ *         For example, for an attribute {@code value}, the property key would be {@code <prefix>value}.
+ *     </li>
+ *     <li><strong>Type Conversion:</strong> If a configuration property exists for an attribute, it is converted to the attribute's type
+ *         using the Spring {@link org.springframework.core.convert.ConversionService}. If conversion fails or the property is missing,
+ *         the original annotation attribute value is retained.
+ *     </li>
+ * </ol>
+ *
+ * <h3>Example Usage</h3>
+ *
+ * <h4>1. Default Prefix Behavior</h4>
+ * Given an annotation {@code @PropertySource(name = "default", ignoreResourceNotFound = false)}:
+ * <pre>{@code
+ * // application.properties
+ * microsphere.spring.prefix.PropertySource.name=my-custom-source
+ * microsphere.spring.prefix.PropertySource.ignoreResourceNotFound=true
+ *
+ * // Resulting AnnotationAttributes:
+ * // name = "my-custom-source"
+ * // ignoreResourceNotFound = true
+ * }</pre>
+ *
+ * <h4>2. Custom Prefix Behavior</h4>
+ * You can define a custom prefix for a specific annotation type:
+ * <pre>{@code
+ * // application.properties
+ * # Define a custom prefix for PropertySource annotation
+ * microsphere.spring.prefix.org.springframework.context.annotation.PropertySource=app.prop.source.
+ *
+ * # Use the custom prefix to override attributes
+ * app.prop.source.name=overridden-name
+ * app.prop.source.ignoreResourceNotFound=true
+ *
+ * // Resulting AnnotationAttributes for @PropertySource:
+ * // name = "overridden-name"
+ * // ignoreResourceNotFound = true
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see OverrideAnnotationAttributesStrategy
+ * @see org.springframework.core.env.Environment
  * @since 1.0.0
  */
 public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implements OverrideAnnotationAttributesStrategy,
@@ -53,11 +110,26 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implement
 
     private ConfigurableEnvironment environment;
 
+    /**
+     * Overrides the original annotation attributes with values from configuration properties.
+     * <p>
+     * This method attempts to find configuration properties that match the annotation's attributes.
+     * If a matching property is found and can be converted to the attribute's type, it replaces
+     * the original value. Otherwise, the original value is retained.
+     *
+     * @param originalAttributes the original annotation attributes to be potentially overridden
+     * @param annotationType     the type of the annotation being processed
+     * @param annotationMetadata the metadata of the annotated element
+     * @return a new {@link AnnotationAttributes} instance containing the overridden values,
+     * or the original attributes if no overrides are applicabl
+     */
     @Override
     public AnnotationAttributes override(AnnotationAttributes originalAttributes, Class<? extends Annotation> annotationType,
                                          AnnotationMetadata annotationMetadata) {
         Map<String, Object> configurationProperties = getConfigurationProperties(annotationType);
         if (configurationProperties.isEmpty()) {
+            String propertyNamePrefix = getPropertyNamePrefix(annotationType);
+            logger.warn("No configuration properties found for annotation : {}", annotationType);
             return originalAttributes;
         }
         ConversionService conversionService = getConversionService(this.environment);
@@ -89,26 +161,130 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implement
         return newAttributes;
     }
 
-    Map<String, Object> getConfigurationProperties(Class<? extends Annotation> annotationType) {
+    /**
+     * Gets the configuration properties associated with the specified annotation type.
+     * <p>
+     * This method retrieves sub-properties from the environment using the property name prefix
+     * derived from the given annotation type. These properties are intended to override
+     * the default attributes of the annotation.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Assume the environment contains the following properties:
+     * // microsphere.spring.prefix.PropertySource.name = "myProperties"
+     * // microsphere.spring.prefix.PropertySource.ignoreResourceNotFound = true
+     *
+     * Map<String, Object> properties = getConfigurationProperties(PropertySource.class);
+     * // properties will contain:
+     * // { "name": "myProperties", "ignoreResourceNotFound": true }
+     * }
+     * </pre>
+     *
+     * @param annotationType the type of the annotation for which to retrieve configuration properties
+     * @return a map of configuration properties keyed by attribute name, or an empty map if none are found
+     */
+    @Nonnull
+    protected Map<String, Object> getConfigurationProperties(Class<? extends Annotation> annotationType) {
         String propertyNamePrefix = getPropertyNamePrefix(annotationType);
         return getSubProperties(this.environment, propertyNamePrefix);
     }
 
-    String getPropertyName(Class<? extends Annotation> annotationType, String attributeName) {
+    /**
+     * Gets the full property name for the given annotation attribute.
+     * <p>
+     * The property name is constructed by concatenating the property name prefix
+     * (obtained via {@link #getPropertyNamePrefix(Class)}) with the attribute name.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *  String propertyName = getPropertyName(PropertySource.class, "factory");
+     *  // propertyName == "microsphere.spring.prefix.PropertySource.factory"
+     * }
+     * </pre>
+     *
+     * @param annotationType the type of the annotation
+     * @param attributeName  the name of the annotation attribute
+     * @return the full property name corresponding to the annotation attribute
+     */
+    @Nonnull
+    protected String getPropertyName(Class<? extends Annotation> annotationType, String attributeName) {
         return getPropertyNamePrefix(annotationType) + attributeName;
     }
 
-    String getPropertyNamePrefix(Class<? extends Annotation> annotationType) {
+    /**
+     * Gets the property name prefix for the given annotation type.
+     * <p>
+     * This method determines the prefix by first checking if a specific prefix property is defined
+     * in the environment using {@link #getPrefixPropertyName(Class)}. If not found, it falls back
+     * to the default prefix generated by {@link #getDefaultPropertyNamePrefix(Class)}.
+     * The resulting prefix is then normalized (ensuring it ends with a dot if not empty).
+     *
+     * <h3>Example Usage</h3>
+     * <h4>Default</h4>
+     * <pre>{@code
+     *  String propertyNamePrefix = getPropertyNamePrefix(PropertySource.class);
+     *  // propertyNamePrefix == "microsphere.spring.prefix.PropertySource."
+     *  // the same as invocation on the method getDefaultPropertyNamePrefix(PropertySource.class)
+     * }
+     * </pre>
+     * <h4>Customized Property Name Prefix</h4>
+     * <pre>{@code
+     *  // Assume the following environment property exists:
+     *  // microsphere.spring.prefix.org.springframework.context.annotation.PropertySource = "microsphere.property-source."
+     *  String propertyNamePrefix = getPropertyNamePrefix(PropertySource.class);
+     *  // propertyNamePrefix == "microsphere.property-source."
+     * }
+     * </pre>
+     *
+     * @param annotationType the type of the annotation
+     * @return the normalized property name prefix
+     */
+    @Nonnull
+    protected String getPropertyNamePrefix(Class<? extends Annotation> annotationType) {
         String prefixPropertyName = getPrefixPropertyName(annotationType);
         String propertyNamePrefix = environment.getProperty(prefixPropertyName, String.class, getDefaultPropertyNamePrefix(annotationType));
         return normalizePrefix(propertyNamePrefix);
     }
 
-    static String getPrefixPropertyName(Class<? extends Annotation> annotationType) {
+    /**
+     * Gets the property name used to look up the prefix for the given annotation type.
+     * <p>
+     * The property name is constructed by concatenating the {@link io.microsphere.spring.constants.PropertyConstants#PREFIX_PROPERTY_NAME_PREFIX}
+     * with the fully qualified name of the annotation class.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *  String prefixPropertyName = getPrefixPropertyName(PropertySource.class);
+     *  // prefixPropertyName == "microsphere.spring.prefix.io.microsphere.spring.context.annotation.PropertySource"
+     * }
+     * </pre>
+     *
+     * @param annotationType the type of the annotation
+     * @return the property name for the prefix
+     */
+    @Nonnull
+    public static String getPrefixPropertyName(Class<? extends Annotation> annotationType) {
         return PREFIX_PROPERTY_NAME_PREFIX + annotationType.getName();
     }
 
-    static String getDefaultPropertyNamePrefix(Class<? extends Annotation> annotationType) {
+    /**
+     * Gets the default property name prefix for the given annotation type.
+     * <p>
+     * The default prefix is constructed by concatenating the {@link io.microsphere.spring.constants.PropertyConstants#PREFIX_PROPERTY_NAME_PREFIX}
+     * with the simple name of the annotation class and a dot character.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *  String defaultPropertyNamePrefix = getDefaultPropertyNamePrefix(PropertySource.class);
+     *  // defaultPropertyNamePrefix == "microsphere.spring.prefix.PropertySource."
+     * }
+     * </pre>
+     *
+     * @param annotationType the type of the annotation
+     * @return the default property name prefix
+     */
+    @Nonnull
+    public static String getDefaultPropertyNamePrefix(Class<? extends Annotation> annotationType) {
         return PREFIX_PROPERTY_NAME_PREFIX + annotationType.getSimpleName() + DOT_CHAR;
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategy.java
@@ -54,7 +54,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategy implement
     private ConfigurableEnvironment environment;
 
     @Override
-    public AnnotationAttributes override(Class<? extends Annotation> annotationType, AnnotationAttributes originalAttributes,
+    public AnnotationAttributes override(AnnotationAttributes originalAttributes, Class<? extends Annotation> annotationType,
                                          AnnotationMetadata annotationMetadata) {
         Map<String, Object> configurationProperties = getConfigurationProperties(annotationType);
         if (configurationProperties.isEmpty()) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptional.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptional.java
@@ -46,6 +46,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(TYPE)
 @Retention(RUNTIME)
 @Documented
+@OverrideAnnotationAttributes
 @Import(ImportOptionalSelector.class)
 public @interface ImportOptional {
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributes.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.annotation.Nonnull;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The meta-annotation that indicates the attributes of the annotation should be overridden.
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see Import
+ * @see BeanCapableImportCandidate
+ * @since 1.0.0
+ */
+@Target(ANNOTATION_TYPE)
+@Retention(RUNTIME)
+@Documented
+@Inherited
+public @interface OverrideAnnotationAttributes {
+
+    /**
+     * The strategy class for overriding annotation attributes.
+     *
+     * @return {@link ConfigurationPropertyOverrideAnnotationAttributesStrategy} as default, the implementation class
+     * must be a concrete class and have a default constructor.
+     */
+    @Nonnull
+    Class<? extends OverrideAnnotationAttributesStrategy> strategy() default ConfigurationPropertyOverrideAnnotationAttributesStrategy.class;
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributes.java
@@ -19,6 +19,8 @@ package io.microsphere.spring.context.annotation;
 
 import io.microsphere.annotation.Nonnull;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.context.annotation.ImportSelector;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
@@ -30,10 +32,44 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The meta-annotation that indicates the attributes of the annotation should be overridden.
+ * <p>
+ * The annotation must {@link Import @Import} an {@link ImportBeanDefinitionRegistrar} or {@link ImportSelector}
+ * implementation that must extend the abstract class {@link BeanCapableImportCandidate} or it subtype.
+ * <p>
+ * <h3>Example Usage</h3>
+ * <pre>{@code
+ * // Define a custom annotation with an override strategy
+ * @OverrideAnnotationAttributes(strategy = MyCustomStrategy.class)
+ * @Import(MyImportRegistrar.class)
+ * public @interface MyCustomImport {
+ *     String value() default "";
+ * }
+ *
+ * // In your ImportSelector or ImportBeanDefinitionRegistrar implementation:
+ * public class MyImportRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
+ *     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+ *          // ...
+ *     }
+ * }
+ *
+ * // Define an override strategy
+ * public class MyCustomStrategy implements OverrideAnnotationAttributesStrategy {
+ *     @Override
+ *     public AnnotationAttributes override(AnnotationAttributes originalAttributes, Class<? extends Annotation> annotationType, AnnotationMetadata metadata) {
+ *         // Custom logic to modify attributes
+ *         return originalAttributes;
+ *     }
+ * }
+ *
+ * @MyCustomImport
+ * public class AppConfig { }
+ * }</pre>
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see OverrideAnnotationAttributesStrategy
+ * @see ConfigurationPropertyOverrideAnnotationAttributesStrategy
+ * @see BeanCapableImportCandidate#getOverriddenAnnotationAttributes
  * @see Import
- * @see BeanCapableImportCandidate
  * @since 1.0.0
  */
 @Target(ANNOTATION_TYPE)

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributesStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.annotation.Nonnull;
+import io.microsphere.annotation.Nullable;
+import io.microsphere.spring.beans.BeanUtils;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * The strategy interface for overriding annotation attributes.
+ * <p>
+ * The instance of this interface is similar to the Spring bean, which will be
+ * {@link BeanUtils#initializeBean(Object, ApplicationContext) initialized} and not
+ * be registered as a Spring bean into the Spring {@link BeanFactory}.
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see OverrideAnnotationAttributes
+ * @see BeanUtils#initializeBean(Object, ApplicationContext)
+ * @since 1.0.0
+ */
+public interface OverrideAnnotationAttributesStrategy {
+
+    /**
+     * Override annotation attributes
+     *
+     * @param annotationType     the annotation type
+     * @param originalAttributes the original annotation attributes
+     * @param annotationMetadata the annotation metadata
+     * @return <code>null</code> if not override, or the overridden annotation attributes
+     */
+    @Nullable
+    AnnotationAttributes override(@Nonnull Class<? extends Annotation> annotationType,
+                                  @Nonnull AnnotationAttributes originalAttributes,
+                                  @Nonnull AnnotationMetadata annotationMetadata);
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributesStrategy.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/OverrideAnnotationAttributesStrategy.java
@@ -44,13 +44,13 @@ public interface OverrideAnnotationAttributesStrategy {
     /**
      * Override annotation attributes
      *
-     * @param annotationType     the annotation type
      * @param originalAttributes the original annotation attributes
+     * @param annotationType     the annotation type
      * @param annotationMetadata the annotation metadata
      * @return <code>null</code> if not override, or the overridden annotation attributes
      */
     @Nullable
-    AnnotationAttributes override(@Nonnull Class<? extends Annotation> annotationType,
-                                  @Nonnull AnnotationAttributes originalAttributes,
+    AnnotationAttributes override(@Nonnull AnnotationAttributes originalAttributes,
+                                  @Nonnull Class<? extends Annotation> annotationType,
                                   @Nonnull AnnotationMetadata annotationMetadata);
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EnableEventExtension.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EnableEventExtension.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.context.event;
 
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -56,6 +57,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({TYPE, ANNOTATION_TYPE})
 @Retention(RUNTIME)
 @Documented
+@OverrideAnnotationAttributes
 @Import(EventExtensionRegistrar.class)
 public @interface EnableEventExtension {
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionAttributes.java
@@ -18,11 +18,9 @@
 package io.microsphere.spring.context.event;
 
 import io.microsphere.annotation.Nonnull;
-import io.microsphere.annotation.Nullable;
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.core.annotation.GenericAnnotationAttributes;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
-import org.springframework.core.env.PropertyResolver;
-import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * The {@link ResolvablePlaceholderAnnotationAttributes} for {@link EnableEventExtension @EnableEventExtension}
@@ -48,8 +46,8 @@ class EventExtensionAttributes extends ResolvablePlaceholderAnnotationAttributes
      */
     static final String EXECUTOR_FOR_LISTENER_ATTRIBUTE_NAME = "executorForListener";
 
-    EventExtensionAttributes(AnnotationMetadata metadata, @Nullable PropertyResolver propertyResolver) {
-        super(metadata.getAnnotationAttributes(ANNOTATION_CLASS_NAME), EnableEventExtension.class, propertyResolver);
+    EventExtensionAttributes(GenericAnnotationAttributes<EnableEventExtension> annotationAttributes) {
+        super(annotationAttributes);
     }
 
     @Nonnull

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
@@ -16,25 +16,23 @@
  */
 package io.microsphere.spring.context.event;
 
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
-import org.springframework.core.env.Environment;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanSource.registerBeans;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.getBeanDefinition;
 import static io.microsphere.spring.context.event.EnableEventExtension.NO_EXECUTOR;
@@ -54,16 +52,12 @@ import static org.springframework.context.support.AbstractApplicationContext.APP
  * @see TaskExecutor
  * @since 1.0.0
  */
-class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
-
-    private static final Logger logger = getLogger(EventExtensionRegistrar.class);
+class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableEventExtension> implements ImportBeanDefinitionRegistrar {
 
     /**
      * The attribute name of the name of {@link EnableEventExtension} annotated on the class
      */
     static final String CLASS_NAME_ATTRIBUTE_NAME = "@className";
-
-    private Environment environment;
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
@@ -71,8 +65,9 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
     }
 
     void registerApplicationEventMulticaster(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+        ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes = getAnnotationAttributes(metadata);
 
-        EventExtensionAttributes attributes = new EventExtensionAttributes(metadata, this.environment);
+        EventExtensionAttributes attributes = new EventExtensionAttributes(annotationAttributes);
 
         boolean intercepted = attributes.isIntercepted();
         String executorForListener = attributes.getExecutorForListener();
@@ -139,7 +134,7 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
         if (intercepted) {
             // Remove the original BeanDefinition of ApplicationEventMulticaster
             registry.removeBeanDefinition(beanName);
-            String resetBeanName = getResetBeanName(this.environment);
+            String resetBeanName = getResetBeanName(super.environment);
             // Reset bean name and re-register the original BeanDefinition of ApplicationEventMulticaster
             registry.registerBeanDefinition(resetBeanName, existedBeanDefinition);
             // Build BeanDefinition InterceptingApplicationEventMulticasterProxy with bean name
@@ -176,10 +171,5 @@ class EventExtensionRegistrar implements ImportBeanDefinitionRegistrar, Environm
             // The bean class must have setTaskExecutor(Executor) method
             propertyValues.addPropertyValue("taskExecutor", new RuntimeBeanReference(executorBeanName));
         }
-    }
-
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.environment = environment;
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/AnnotationUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/AnnotationUtils.java
@@ -610,6 +610,28 @@ public abstract class AnnotationUtils {
     }
 
     /**
+     * Converts the specified {@link Map} of annotation attributes into an {@link AnnotationAttributes} instance.
+     * <p>
+     * If the input map is already an instance of {@link AnnotationAttributes}, it will be returned directly.
+     * Otherwise, a new {@link AnnotationAttributes} instance will be created from the provided map.
+     * If the input is {@code null}, an empty {@link AnnotationAttributes} instance is returned.
+     *
+     * @param annotationAttributes the map of annotation attributes, may be {@code null}
+     * @return an {@link AnnotationAttributes} instance, never {@code null}
+     * @see AnnotationAttributes
+     * @see AnnotationAttributes#AnnotationAttributes()
+     * @see AnnotationAttributes#AnnotationAttributes(Map)
+     */
+    @Nonnull
+    public static AnnotationAttributes ofAnnotationAttributes(@Nullable Map<String, Object> annotationAttributes) {
+        if (annotationAttributes == null) {
+            return new AnnotationAttributes();
+        }
+        return annotationAttributes instanceof AnnotationAttributes ? (AnnotationAttributes) annotationAttributes :
+                new AnnotationAttributes(annotationAttributes);
+    }
+
+    /**
      * filter the {@link AnnotationAttributes}
      *
      * @param annotationAttributes the attributes of specified {@link Annotation}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributes.java
@@ -29,10 +29,12 @@ import java.util.Set;
 import static io.microsphere.collection.SetUtils.newFixedLinkedHashSet;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.findAnnotationType;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
+import static io.microsphere.util.ArrayUtils.length;
 import static io.microsphere.util.Assert.assertNotNull;
 import static java.util.Arrays.deepHashCode;
 import static java.util.Arrays.deepToString;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.deepEquals;
 
 /**
@@ -86,16 +88,19 @@ public class GenericAnnotationAttributes<A extends Annotation> extends Annotatio
             return false;
         }
 
-        if (this.size() == that.size()) {
-            for (Entry<String, Object> entry : this.entrySet()) {
-                String attributeName = entry.getKey();
-                Object attributeValue = entry.getValue();
-                Object thatAttributeValue = that.get(attributeName);
-                if (!deepEquals(attributeValue, thatAttributeValue)) {
-                    return false;
-                }
+        if (this.size() != that.size()) {
+            return false;
+        }
+
+        for (Entry<String, Object> entry : this.entrySet()) {
+            String attributeName = entry.getKey();
+            Object attributeValue = entry.getValue();
+            Object thatAttributeValue = that.get(attributeName);
+            if (!deepEquals(attributeValue, thatAttributeValue)) {
+                return false;
             }
         }
+
         return true;
     }
 
@@ -171,6 +176,26 @@ public class GenericAnnotationAttributes<A extends Annotation> extends Annotatio
     }
 
     /**
+     * Create an instance of {@link GenericAnnotationAttributes} from the specified {@link Map map} of attributes
+     * and the {@link Class class} of {@link Annotation annotation}.
+     *
+     * @param attributes     the map of annotation attributes, must not be null
+     * @param annotationType the {@link Class class} of {@link Annotation annotation}, must not be null
+     * @param <A>            the {@link Class class} of {@link Annotation annotation}
+     * @return a new instance of {@link GenericAnnotationAttributes}
+     * @throws IllegalArgumentException if {@code annotationType} is null
+     * @see #GenericAnnotationAttributes(Map, Class)
+     */
+    @Nonnull
+    public static <A extends Annotation> GenericAnnotationAttributes<A> of(@Nonnull Map<String, Object> attributes,
+                                                                           @Nonnull Class<A> annotationType) {
+        if (attributes instanceof GenericAnnotationAttributes) {
+            return (GenericAnnotationAttributes) attributes;
+        }
+        return new GenericAnnotationAttributes<>(attributes, annotationType);
+    }
+
+    /**
      * Create a {@link Set set} of {@link GenericAnnotationAttributes}
      *
      * @param attributesArray
@@ -179,7 +204,7 @@ public class GenericAnnotationAttributes<A extends Annotation> extends Annotatio
     @Nonnull
     @Immutable
     public static Set<AnnotationAttributes> ofSet(@Nullable AnnotationAttributes... attributesArray) {
-        int length = attributesArray == null ? 0 : attributesArray.length;
+        int length = length(attributesArray);
 
         if (length < 1) {
             return emptySet();
@@ -191,6 +216,6 @@ public class GenericAnnotationAttributes<A extends Annotation> extends Annotatio
             annotationAttributesSet.add(of(annotationAttributes));
         }
 
-        return annotationAttributesSet;
+        return unmodifiableSet(annotationAttributesSet);
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributes.java
@@ -138,6 +138,9 @@ public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> ext
      */
     @Nonnull
     public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull GenericAnnotationAttributes<A> attributes) {
+        if (attributes instanceof ResolvablePlaceholderAnnotationAttributes) {
+            return (ResolvablePlaceholderAnnotationAttributes) attributes;
+        }
         return new ResolvablePlaceholderAnnotationAttributes<>(attributes);
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributes.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributes.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.core.annotation;
 
+import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.annotation.Nullable;
 import io.microsphere.spring.core.env.PropertyResolverUtils;
@@ -42,14 +43,68 @@ import static java.util.Collections.emptySet;
  */
 public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> extends GenericAnnotationAttributes<A> {
 
+    /**
+     * Constructs a new {@link ResolvablePlaceholderAnnotationAttributes} instance from the specified {@link Annotation}.
+     * <p>
+     * Placeholders in the annotation attribute values will be resolved using the provided {@link PropertyResolver}.
+     * If the {@code propertyResolver} is {@code null}, placeholders will remain unresolved.
+     *
+     * @param annotation       the source annotation, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @example <pre>{@code
+     * // Given an annotation instance and a PropertyResolver
+     * MyAnnotation annotation = ...;
+     * PropertyResolver resolver = ...;
+     *
+     * // Create ResolvablePlaceholderAnnotationAttributes with placeholder resolution
+     * ResolvablePlaceholderAnnotationAttributes<MyAnnotation> resolvableAttrs =
+     *     new ResolvablePlaceholderAnnotationAttributes<>(annotation, resolver);
+     * }</pre>
+     */
     public ResolvablePlaceholderAnnotationAttributes(@Nonnull A annotation, @Nullable PropertyResolver propertyResolver) {
         this(getAnnotationAttributes(annotation, false), (Class<A>) annotation.annotationType(), propertyResolver);
     }
 
-    public ResolvablePlaceholderAnnotationAttributes(AnnotationAttributes another, @Nullable PropertyResolver propertyResolver) {
+    /**
+     * Constructs a new {@link ResolvablePlaceholderAnnotationAttributes} instance by copying the attributes
+     * from another {@link GenericAnnotationAttributes}.
+     * <p>
+     * The placeholders in the attributes will not be resolved as no {@link PropertyResolver} is provided.
+     *
+     * @param another the source {@link GenericAnnotationAttributes} to copy attributes from, must not be {@code null}
+     * @see #ResolvablePlaceholderAnnotationAttributes(GenericAnnotationAttributes, org.springframework.core.env.PropertyResolver)
+     */
+    public ResolvablePlaceholderAnnotationAttributes(GenericAnnotationAttributes<A> another) {
+        this(another, null);
+    }
+
+    /**
+     * Constructs a new {@link ResolvablePlaceholderAnnotationAttributes} instance by copying the attributes
+     * from another {@link GenericAnnotationAttributes} and resolving placeholders using the given {@link PropertyResolver}.
+     * <p>
+     * If the {@code propertyResolver} is {@code null}, placeholders in the attributes will not be resolved.
+     *
+     * @param another          the source {@link GenericAnnotationAttributes} to copy attributes from, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @see #ResolvablePlaceholderAnnotationAttributes(GenericAnnotationAttributes)
+     * @see PropertyResolverUtils#resolvePlaceholders(Map, PropertyResolver)
+     */
+    public ResolvablePlaceholderAnnotationAttributes(GenericAnnotationAttributes<A> another, @Nullable PropertyResolver propertyResolver) {
         this(another, findAnnotationType(another), propertyResolver);
     }
 
+    /**
+     * Constructs a new {@link ResolvablePlaceholderAnnotationAttributes} instance with the specified attributes,
+     * annotation type, and property resolver.
+     * <p>
+     * Placeholders in the attribute values will be resolved using the provided {@link PropertyResolver}.
+     * If the {@code propertyResolver} is {@code null}, placeholders will remain unresolved.
+     *
+     * @param another          the map of annotation attributes, must not be {@code null}
+     * @param annotationType   the type of the annotation, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @see PropertyResolverUtils#resolvePlaceholders(Map, PropertyResolver)
+     */
     public ResolvablePlaceholderAnnotationAttributes(Map<String, Object> another, @Nonnull Class<A> annotationType, @Nullable PropertyResolver propertyResolver) {
         super(resolvePlaceholders(another, propertyResolver), annotationType);
     }
@@ -63,15 +118,53 @@ public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> ext
     }
 
     /**
-     * Create an instance of {@link ResolvablePlaceholderAnnotationAttributes} from the specified {@link Annotation annotation}
+     * Creates a {@link ResolvablePlaceholderAnnotationAttributes} instance from the given {@link GenericAnnotationAttributes}.
+     * <p>
+     * The placeholders in the attributes will not be resolved as no {@link PropertyResolver} is provided.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Given an existing GenericAnnotationAttributes instance
+     * GenericAnnotationAttributes<MyAnnotation> attrs = ...;
      *
-     * @param attributes       {@link AnnotationAttributes}
-     * @param propertyResolver {@link PropertyResolver}
-     * @param <A>              the {@link Class class} of {@link Annotation annotation}
-     * @return non-null
+     * // Create a ResolvablePlaceholderAnnotationAttributes without resolving placeholders
+     * ResolvablePlaceholderAnnotationAttributes<MyAnnotation> resolvableAttrs =
+     *     ResolvablePlaceholderAnnotationAttributes.of(attrs);
+     * }</pre>
+     *
+     * @param attributes the source {@link GenericAnnotationAttributes}, must not be {@code null}
+     * @param <A>        the type of the annotation
+     * @return a new {@link ResolvablePlaceholderAnnotationAttributes} instance
      */
     @Nonnull
-    public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull AnnotationAttributes attributes,
+    public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull GenericAnnotationAttributes<A> attributes) {
+        return new ResolvablePlaceholderAnnotationAttributes<>(attributes);
+    }
+
+    /**
+     * Creates a {@link ResolvablePlaceholderAnnotationAttributes} instance from the given {@link GenericAnnotationAttributes}
+     * and resolves placeholders using the provided {@link PropertyResolver}.
+     * <p>
+     * If the {@code propertyResolver} is {@code null}, placeholders in the attributes will not be resolved.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Given an existing GenericAnnotationAttributes instance and a PropertyResolver
+     * GenericAnnotationAttributes<MyAnnotation> attrs = ...;
+     * PropertyResolver resolver = ...;
+     *
+     * // Create a ResolvablePlaceholderAnnotationAttributes with placeholder resolution
+     * ResolvablePlaceholderAnnotationAttributes<MyAnnotation> resolvableAttrs =
+     *     ResolvablePlaceholderAnnotationAttributes.of(attrs, resolver);
+     * }</pre>
+     *
+     * @param attributes       the source {@link GenericAnnotationAttributes}, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @param <A>              the type of the annotation
+     * @return a new {@link ResolvablePlaceholderAnnotationAttributes} instance
+     */
+    @Nonnull
+    public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull GenericAnnotationAttributes<A> attributes,
                                                                                          @Nullable PropertyResolver propertyResolver) {
         if (attributes instanceof ResolvablePlaceholderAnnotationAttributes) {
             return (ResolvablePlaceholderAnnotationAttributes) attributes;
@@ -80,12 +173,26 @@ public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> ext
     }
 
     /**
-     * Create an instance of {@link ResolvablePlaceholderAnnotationAttributes} from the specified {@link Annotation annotation}
+     * Creates a {@link ResolvablePlaceholderAnnotationAttributes} instance from the given {@link Annotation}
+     * and resolves placeholders using the provided {@link PropertyResolver}.
+     * <p>
+     * If the {@code propertyResolver} is {@code null}, placeholders in the annotation attribute values will not be resolved.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Given an annotation instance and a PropertyResolver
+     * MyAnnotation annotation = ...;
+     * PropertyResolver resolver = ...;
      *
-     * @param annotation       {@link Annotation annotation}
-     * @param propertyResolver {@link PropertyResolver}
-     * @param <A>              the {@link Class class} of {@link Annotation annotation}
-     * @return non-null
+     * // Create a ResolvablePlaceholderAnnotationAttributes with placeholder resolution
+     * ResolvablePlaceholderAnnotationAttributes<MyAnnotation> resolvableAttrs =
+     *     ResolvablePlaceholderAnnotationAttributes.of(annotation, resolver);
+     * }</pre>
+     *
+     * @param annotation       the source annotation, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @param <A>              the type of the annotation
+     * @return a new {@link ResolvablePlaceholderAnnotationAttributes} instance
      */
     @Nonnull
     public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull A annotation,
@@ -94,29 +201,62 @@ public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> ext
     }
 
     /**
-     * Create an instance of {@link ResolvablePlaceholderAnnotationAttributes} from the specified {@link Annotation annotation}
+     * Creates a {@link ResolvablePlaceholderAnnotationAttributes} instance from the given map of attributes,
+     * annotation type, and resolves placeholders using the provided {@link PropertyResolver}.
+     * <p>
+     * If the {@code propertyResolver} is {@code null}, placeholders in the attribute values will not be resolved.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Given a map of attributes, annotation type, and a PropertyResolver
+     * Map<String, Object> attrs = new HashMap<>();
+     * attrs.put("value", "${my.property}");
+     * Class<MyAnnotation> annotationType = MyAnnotation.class;
+     * PropertyResolver resolver = ...;
      *
-     * @param attributes       The {@link Map} for the attributes of annotation
-     * @param propertyResolver {@link PropertyResolver}
-     * @param <A>              the {@link Class class} of {@link Annotation annotation}
-     * @return non-null
+     * // Create a ResolvablePlaceholderAnnotationAttributes with placeholder resolution
+     * ResolvablePlaceholderAnnotationAttributes<MyAnnotation> resolvableAttrs =
+     *     ResolvablePlaceholderAnnotationAttributes.of(attrs, annotationType, resolver);
+     * }</pre>
+     *
+     * @param attributes       the map of annotation attributes, must not be {@code null}
+     * @param annotationType   the type of the annotation, must not be {@code null}
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @param <A>              the type of the annotation
+     * @return a new {@link ResolvablePlaceholderAnnotationAttributes} instance
      */
     @Nonnull
-    public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(Map<String, Object> attributes,
+    public static <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> of(@Nonnull Map<String, Object> attributes,
                                                                                          Class<A> annotationType,
                                                                                          @Nullable PropertyResolver propertyResolver) {
         return new ResolvablePlaceholderAnnotationAttributes(attributes, annotationType, propertyResolver);
     }
 
     /**
-     * Create a {@link Set set} of {@link GenericAnnotationAttributes}
+     * Creates a {@link Set} of {@link AnnotationAttributes} from the given array of {@link GenericAnnotationAttributes},
+     * resolving placeholders using the provided {@link PropertyResolver}.
+     * <p>
+     * If the {@code propertyResolver} is {@code null}, placeholders in the attribute values will not be resolved.
+     * If the {@code attributesArray} is {@code null} or empty, an empty set is returned.
+     * <p>
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Given an array of GenericAnnotationAttributes and a PropertyResolver
+     * GenericAnnotationAttributes<MyAnnotation>[] attrsArray = ...;
+     * PropertyResolver resolver = ...;
      *
-     * @param attributesArray
-     * @param propertyResolver
-     * @return non-null
+     * // Create a Set of ResolvablePlaceholderAnnotationAttributes with placeholder resolution
+     * Set<AnnotationAttributes> resolvableAttrsSet =
+     *     ResolvablePlaceholderAnnotationAttributes.ofSet(attrsArray, resolver);
+     * }</pre>
+     *
+     * @param attributesArray  the array of source {@link GenericAnnotationAttributes}, may be {@code null} or empty
+     * @param propertyResolver the {@link PropertyResolver} used to resolve placeholders in attribute values, may be {@code null}
+     * @return a {@link Set} of {@link AnnotationAttributes} with resolved placeholders, or an empty set if the input is null or empty
      */
     @Nonnull
-    public static Set<AnnotationAttributes> ofSet(@Nullable AnnotationAttributes[] attributesArray, @Nullable PropertyResolver propertyResolver) {
+    @Immutable
+    public static Set<AnnotationAttributes> ofSet(@Nullable GenericAnnotationAttributes[] attributesArray, @Nullable PropertyResolver propertyResolver) {
         int length = length(attributesArray);
 
         if (length < 1) {
@@ -125,7 +265,7 @@ public class ResolvablePlaceholderAnnotationAttributes<A extends Annotation> ext
 
         Set<AnnotationAttributes> annotationAttributesSet = newLinkedHashSet();
         for (int i = 0; i < length; i++) {
-            AnnotationAttributes annotationAttributes = attributesArray[i];
+            GenericAnnotationAttributes annotationAttributes = attributesArray[i];
             annotationAttributesSet.add(of(annotationAttributes, propertyResolver));
         }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/env/PropertySourcesUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/env/PropertySourcesUtils.java
@@ -1,6 +1,8 @@
 package io.microsphere.spring.core.env;
 
+import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
+import io.microsphere.annotation.Nullable;
 import io.microsphere.logging.Logger;
 import io.microsphere.util.Utils;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -65,11 +67,13 @@ public abstract class PropertySourcesUtils implements Utils {
      */
     public static final String BOOTSTRAP_PROPERTY_SOURCE_NAME = "bootstrap";
 
+    @Nullable
     public static <T extends PropertySource<?>> T getPropertySource(ConfigurableEnvironment environment, String propertySourceName,
                                                                     Class<T> propertySourceType) {
         return getPropertySource(environment, propertySourceName, propertySourceType, null);
     }
 
+    @Nullable
     public static <T extends PropertySource<?>> T getPropertySource(ConfigurableEnvironment environment, String propertySourceName,
                                                                     Class<T> propertySourceType, Supplier<T> propertySourceSupplierIfAbsent) {
         MutablePropertySources propertySources = environment.getPropertySources();
@@ -102,9 +106,11 @@ public abstract class PropertySourcesUtils implements Utils {
         return targetPropertySource;
     }
 
+    @Nullable
     public static MapPropertySource getMapPropertySource(ConfigurableEnvironment environment, String propertySourceName) {
         return getMapPropertySource(environment, propertySourceName, false);
     }
+
 
     public static MapPropertySource getMapPropertySource(ConfigurableEnvironment environment, String propertySourceName, boolean created) {
         Supplier<MapPropertySource> propertySourceSupplierIfAbsent =
@@ -112,10 +118,12 @@ public abstract class PropertySourcesUtils implements Utils {
         return getPropertySource(environment, propertySourceName, MapPropertySource.class, propertySourceSupplierIfAbsent);
     }
 
+    @Nullable
     public static PropertySource findConfiguredPropertySource(ConfigurableEnvironment environment, String propertyName) {
         return findConfiguredPropertySource(environment.getPropertySources(), propertyName);
     }
 
+    @Nullable
     public static PropertySource findConfiguredPropertySource(Iterable<PropertySource<?>> propertySources, String propertyName) {
         PropertySource configuredPropertySource = null;
         for (PropertySource propertySource : propertySources) {
@@ -130,19 +138,25 @@ public abstract class PropertySourcesUtils implements Utils {
         return configuredPropertySource;
     }
 
+    @Nullable
     public static String findConfiguredPropertySourceName(ConfigurableEnvironment environment, String propertyName) {
         return findConfiguredPropertySourceName(environment.getPropertySources(), propertyName);
     }
 
+    @Nullable
     public static String findConfiguredPropertySourceName(Iterable<PropertySource<?>> propertySources, String propertyName) {
         PropertySource configuredPropertySource = findConfiguredPropertySource(propertySources, propertyName);
         return configuredPropertySource == null ? null : configuredPropertySource.getName();
     }
 
+    @Nonnull
+    @Immutable
     public static Set<String> findPropertyNamesByPrefix(ConfigurableEnvironment environment, String propertyNamePrefix) {
         return findPropertyNames(environment, propertyName -> propertyName.startsWith(propertyNamePrefix));
     }
 
+    @Nonnull
+    @Immutable
     public static Set<String> findPropertyNames(ConfigurableEnvironment environment, Predicate<String> propertyNameFilter) {
         Set<String> propertyNames = newLinkedHashSet();
         for (PropertySource propertySource : environment.getPropertySources()) {
@@ -166,6 +180,8 @@ public abstract class PropertySourcesUtils implements Utils {
      * @return Map
      * @see Properties
      */
+    @Nonnull
+    @Immutable
     public static Map<String, Object> getSubProperties(Iterable<PropertySource<?>> propertySources, String prefix) {
 
         MutablePropertySources mutablePropertySources = new MutablePropertySources();
@@ -186,6 +202,8 @@ public abstract class PropertySourcesUtils implements Utils {
      * @return Map
      * @see Properties
      */
+    @Nonnull
+    @Immutable
     public static Map<String, Object> getSubProperties(ConfigurableEnvironment environment, String prefix) {
         return getSubProperties(environment.getPropertySources(), environment, prefix);
     }
@@ -207,8 +225,9 @@ public abstract class PropertySourcesUtils implements Utils {
      * @param prefix          the prefix of property name
      * @return Map
      * @see Properties
-     * @since 1.0.0
      */
+    @Nonnull
+    @Immutable
     public static Map<String, Object> getSubProperties(PropertySources propertySources, String prefix) {
         return getSubProperties(propertySources, new PropertySourcesPropertyResolver(propertySources), prefix);
     }
@@ -221,8 +240,9 @@ public abstract class PropertySourcesUtils implements Utils {
      * @param prefix           the prefix of property name
      * @return Map
      * @see Properties
-     * @since 1.0.0
      */
+    @Nonnull
+    @Immutable
     public static Map<String, Object> getSubProperties(PropertySources propertySources, PropertyResolver propertyResolver, String prefix) {
 
         Map<String, Object> subProperties = newLinkedHashMap();
@@ -239,8 +259,9 @@ public abstract class PropertySourcesUtils implements Utils {
                     if (!subProperties.containsKey(subName)) { // take first one
                         Object value = source.getProperty(name);
                         if (value instanceof String) {
+                            String propertyValue = (String) value;
                             // Resolve placeholder
-                            value = propertyResolver.resolvePlaceholders((String) value);
+                            value = propertyResolver.resolvePlaceholders(propertyValue);
                         }
                         subProperties.put(subName, value);
                     }
@@ -256,7 +277,6 @@ public abstract class PropertySourcesUtils implements Utils {
      *
      * @param propertySource {@link PropertySource} instance
      * @return non-null
-     * @since 1.0.0
      */
     @Nonnull
     public static String[] getPropertyNames(PropertySource propertySource) {
@@ -308,6 +328,7 @@ public abstract class PropertySourcesUtils implements Utils {
      * @see #DEFAULT_PROPERTIES_PROPERTY_SOURCE_NAME
      * @see #getDefaultProperties(ConfigurableEnvironment, boolean)
      */
+    @Nonnull
     public static Map<String, Object> getDefaultProperties(ConfigurableEnvironment environment) {
         return getDefaultProperties(environment, true);
     }
@@ -322,6 +343,7 @@ public abstract class PropertySourcesUtils implements Utils {
      * @see #DEFAULT_PROPERTIES_PROPERTY_SOURCE_NAME
      * @see #getDefaultProperties(ConfigurableEnvironment, boolean)
      */
+    @Nonnull
     public static Map<String, Object> getDefaultProperties(ConfigurableEnvironment environment, boolean createIfAbsent) {
         Map<String, Object> defaultProperties = null;
         MapPropertySource defaultPropertiesPropertySource = getDefaultPropertiesPropertySource(environment, createIfAbsent);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/PropertiesUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/PropertiesUtils.java
@@ -21,11 +21,11 @@ import io.microsphere.annotation.Nullable;
 import io.microsphere.util.Utils;
 import org.springframework.core.env.PropertyResolver;
 
-import java.io.IOException;
 import java.io.StringReader;
 import java.util.Properties;
 
 import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
+import static io.microsphere.lang.function.ThrowableAction.execute;
 import static org.springframework.util.StringUtils.arrayToDelimitedString;
 
 /**
@@ -43,9 +43,8 @@ public abstract class PropertiesUtils implements Utils {
      *
      * @param propertiesValue the specified {@code propertiesValue}
      * @return non-null
-     * @throws IOException if an I/O error occurs
      */
-    public static Properties loadProperties(String... propertiesValue) throws IOException {
+    public static Properties loadProperties(String... propertiesValue) {
         return loadProperties(propertiesValue, null);
     }
 
@@ -55,15 +54,17 @@ public abstract class PropertiesUtils implements Utils {
      * @param propertiesValue  the specified {@code propertiesValue}
      * @param propertyResolver {@link PropertyResolver}
      * @return non-null
-     * @throws IOException if an I/O error occurs
      */
-    public static Properties loadProperties(String[] propertiesValue, @Nullable PropertyResolver propertyResolver) throws IOException {
+    public static Properties loadProperties(String[] propertiesValue, @Nullable PropertyResolver propertyResolver) {
         Properties properties = new Properties();
         String content = arrayToDelimitedString(propertiesValue, LINE_SEPARATOR);
+        final String resolvedText;
         if (propertyResolver != null) {
-            content = propertyResolver.resolvePlaceholders(content);
+            resolvedText = propertyResolver.resolvePlaceholders(content);
+        } else {
+            resolvedText = content;
         }
-        properties.load(new StringReader(content));
+        execute(() -> properties.load(new StringReader(resolvedText)));
         return properties;
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/PropertiesUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/io/support/PropertiesUtils.java
@@ -17,7 +17,9 @@
 
 package io.microsphere.spring.core.io.support;
 
+import io.microsphere.annotation.Nullable;
 import io.microsphere.util.Utils;
+import org.springframework.core.env.PropertyResolver;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -44,8 +46,23 @@ public abstract class PropertiesUtils implements Utils {
      * @throws IOException if an I/O error occurs
      */
     public static Properties loadProperties(String... propertiesValue) throws IOException {
+        return loadProperties(propertiesValue, null);
+    }
+
+    /**
+     * Load {@link Properties} from the specified {@code propertiesValue}
+     *
+     * @param propertiesValue  the specified {@code propertiesValue}
+     * @param propertyResolver {@link PropertyResolver}
+     * @return non-null
+     * @throws IOException if an I/O error occurs
+     */
+    public static Properties loadProperties(String[] propertiesValue, @Nullable PropertyResolver propertyResolver) throws IOException {
         Properties properties = new Properties();
         String content = arrayToDelimitedString(propertiesValue, LINE_SEPARATOR);
+        if (propertyResolver != null) {
+            content = propertyResolver.resolvePlaceholders(content);
+        }
         properties.load(new StringReader(content));
         return properties;
     }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
@@ -335,6 +335,7 @@ public class BeanUtilsTest {
             assertThrows(RuntimeException.class, () -> initializeBean(failedBean, context));
         }, Config.class, TestBean.class, TestBean2.class);
     }
+
     @Test
     public void testInvokeBeanInterfaces() {
         testInSpringContainer(context -> {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/BeanUtilsTest.java
@@ -38,6 +38,7 @@ import static io.microsphere.spring.beans.BeanUtils.getBeanIfAvailable;
 import static io.microsphere.spring.beans.BeanUtils.getBeanNames;
 import static io.microsphere.spring.beans.BeanUtils.getOptionalBean;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
+import static io.microsphere.spring.beans.BeanUtils.initializeBean;
 import static io.microsphere.spring.beans.BeanUtils.invokeAwareInterfaces;
 import static io.microsphere.spring.beans.BeanUtils.invokeBeanClassLoaderAware;
 import static io.microsphere.spring.beans.BeanUtils.invokeBeanFactoryAware;
@@ -75,6 +76,13 @@ public class BeanUtilsTest {
 
     @ClassRule
     public static final LoggingLevelsRule LOGGING_LEVELS_RULE = levels("TRACE", "INFO", "ERROR");
+
+    static final InitializingBean vaildBean = () -> {
+    };
+
+    static final InitializingBean failedBean = () -> {
+        throw new Exception("For testing");
+    };
 
     @Configuration
     public static class Config {
@@ -314,13 +322,21 @@ public class BeanUtilsTest {
     }
 
     @Test
+    public void testInitializeBean() {
+        testInSpringContainer(context -> {
+            TestBean bean = context.getBean(TestBean.class);
+            initializeBean(bean, (ApplicationContext) context);
+            initializeBean(bean, context);
+            initializeBean(null, context);
+            initializeBean(bean, null);
+            initializeBean(vaildBean, (ApplicationContext) context);
+            initializeBean(vaildBean, null);
+            assertThrows(RuntimeException.class, () -> initializeBean(failedBean, (ApplicationContext) context));
+            assertThrows(RuntimeException.class, () -> initializeBean(failedBean, context));
+        }, Config.class, TestBean.class, TestBean2.class);
+    }
+    @Test
     public void testInvokeBeanInterfaces() {
-        InitializingBean vaildBean = () -> {
-        };
-        InitializingBean failedBean = () -> {
-            throw new Exception("For testing");
-        };
-
         testInSpringContainer(context -> {
             TestBean bean = context.getBean(TestBean.class);
             invokeBeanInterfaces(bean, (ApplicationContext) context);

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/constants/PropertyConstantsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/constants/PropertyConstantsTest.java
@@ -23,6 +23,7 @@ import static io.microsphere.spring.constants.PropertyConstants.BEANS_PROPERTY_N
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_PROPERTY_VALUE;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.constants.PropertyConstants.MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX;
+import static io.microsphere.spring.constants.PropertyConstants.PREFIX_PROPERTY_NAME_PREFIX;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -37,6 +38,7 @@ public class PropertyConstantsTest {
     @Test
     public void test() {
         assertEquals("microsphere.spring.", MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.spring.prefix.", PREFIX_PROPERTY_NAME_PREFIX);
         assertEquals("microsphere.spring.beans.", BEANS_PROPERTY_NAME_PREFIX);
         assertEquals("auto-registered", AUTO_REGISTERED_PROPERTY_NAME_SUFFIX);
         assertEquals("true", DEFAULT_AUTO_REGISTERED_PROPERTY_VALUE);

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
@@ -79,7 +79,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1 + "," + VALUE_2);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ATTRIBUTES, ANNOTATION_CLASS, null);
         assertArrayEquals(ofArray(VALUE_1, VALUE_2), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
@@ -88,7 +88,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ATTRIBUTES, ANNOTATION_CLASS, null);
         assertArrayEquals(ATTRIBUTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
@@ -97,13 +97,13 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + "a", VALUE_1);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ATTRIBUTES, ANNOTATION_CLASS, null);
         assertArrayEquals(ATTRIBUTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
     @Test
     public void testOverrieOnNoConfigurationProperties() {
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ATTRIBUTES, ANNOTATION_CLASS, null);
         assertSame(ATTRIBUTES, overriddenAttributtes);
     }
 
@@ -112,7 +112,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + FACTORY_ATTRIBUTE_NAME, EMPTY_STRING);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ATTRIBUTES, ANNOTATION_CLASS, null);
         assertEquals(ATTRIBUTES.getClass(FACTORY_ATTRIBUTE_NAME), overriddenAttributtes.getClass(FACTORY_ATTRIBUTE_NAME));
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
@@ -53,7 +53,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
 
     private static final Class<PropertySource> ANNOTATION_CLASS = PropertySource.class;
 
-    private static final AnnotationAttributes IMPORT_OPTIONAL_ATTRIBUTTES = getAnnotationAttributes(ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.class,
+    private static final AnnotationAttributes ATTRIBUTES = getAnnotationAttributes(ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.class,
             ANNOTATION_CLASS, null, false);
 
     private static final String VALUE_ATTRIBUTE_NAME = "value";
@@ -71,7 +71,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         this.strategy = new ConfigurationPropertyOverrideAnnotationAttributesStrategy();
         this.strategy.setEnvironment(environment);
 
-        assertArrayEquals(ofArray(VALUE_1), IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME));
+        assertArrayEquals(ofArray(VALUE_1), ATTRIBUTES.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1 + "," + VALUE_2);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
         assertArrayEquals(ofArray(VALUE_1, VALUE_2), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
@@ -88,8 +88,8 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
-        assertArrayEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        assertArrayEquals(ATTRIBUTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
     @Test
@@ -97,14 +97,14 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + "a", VALUE_1);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
-        assertArrayEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        assertArrayEquals(ATTRIBUTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
     }
 
     @Test
     public void testOverrieOnNoConfigurationProperties() {
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
-        assertSame(IMPORT_OPTIONAL_ATTRIBUTTES, overriddenAttributtes);
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        assertSame(ATTRIBUTES, overriddenAttributtes);
     }
 
     @Test
@@ -112,8 +112,8 @@ public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
         String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
         environment.setProperty(propertyNamePrefix + FACTORY_ATTRIBUTE_NAME, EMPTY_STRING);
 
-        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
-        assertEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getClass(FACTORY_ATTRIBUTE_NAME), overriddenAttributtes.getClass(FACTORY_ATTRIBUTE_NAME));
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, ATTRIBUTES, null);
+        assertEquals(ATTRIBUTES.getClass(FACTORY_ATTRIBUTE_NAME), overriddenAttributtes.getClass(FACTORY_ATTRIBUTE_NAME));
     }
 
     @Test

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Map;
+
+import static io.microsphere.spring.context.annotation.ConfigurationPropertyOverrideAnnotationAttributesStrategy.getDefaultPropertyNamePrefix;
+import static io.microsphere.spring.context.annotation.ConfigurationPropertyOverrideAnnotationAttributesStrategy.getPrefixPropertyName;
+import static io.microsphere.spring.context.annotation.ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.VALUE_1;
+import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
+import static io.microsphere.util.ArrayUtils.ofArray;
+import static io.microsphere.util.StringUtils.EMPTY_STRING;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * {@link ConfigurationPropertyOverrideAnnotationAttributesStrategy} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ConfigurationPropertyOverrideAnnotationAttributesStrategy
+ * @since 1.0.0
+ */
+@PropertySource(value = VALUE_1)
+public class ConfigurationPropertyOverrideAnnotationAttributesStrategyTest {
+
+    static final String VALUE_1 = "classpath:/com/myco/app.properties";
+
+    static final String VALUE_2 = "file:/path/to/file.xml";
+
+    private static final Class<PropertySource> ANNOTATION_CLASS = PropertySource.class;
+
+    private static final AnnotationAttributes IMPORT_OPTIONAL_ATTRIBUTTES = getAnnotationAttributes(ConfigurationPropertyOverrideAnnotationAttributesStrategyTest.class,
+            ANNOTATION_CLASS, null, false);
+
+    private static final String VALUE_ATTRIBUTE_NAME = "value";
+
+    private static final String FACTORY_ATTRIBUTE_NAME = "factory";
+
+
+    private MockEnvironment environment;
+
+    private ConfigurationPropertyOverrideAnnotationAttributesStrategy strategy;
+
+    @Before
+    public void setUp() {
+        this.environment = new MockEnvironment();
+        this.strategy = new ConfigurationPropertyOverrideAnnotationAttributesStrategy();
+        this.strategy.setEnvironment(environment);
+
+        assertArrayEquals(ofArray(VALUE_1), IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME));
+    }
+
+    @Test
+    public void testOverride() {
+        String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
+        environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1 + "," + VALUE_2);
+
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        assertArrayEquals(ofArray(VALUE_1, VALUE_2), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
+    }
+
+    @Test
+    public void testOverrideOnSameConfigurationProperties() {
+        String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
+        environment.setProperty(propertyNamePrefix + VALUE_ATTRIBUTE_NAME, VALUE_1);
+
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        assertArrayEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
+    }
+
+    @Test
+    public void testOverrideOnDifferentConfigurationProperties() {
+        String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
+        environment.setProperty(propertyNamePrefix + "a", VALUE_1);
+
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        assertArrayEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getStringArray(VALUE_ATTRIBUTE_NAME), overriddenAttributtes.getStringArray(VALUE_ATTRIBUTE_NAME));
+    }
+
+    @Test
+    public void testOverrieOnNoConfigurationProperties() {
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        assertSame(IMPORT_OPTIONAL_ATTRIBUTTES, overriddenAttributtes);
+    }
+
+    @Test
+    public void testOverrideOnInvalidConfigurationProperties() {
+        String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
+        environment.setProperty(propertyNamePrefix + FACTORY_ATTRIBUTE_NAME, EMPTY_STRING);
+
+        AnnotationAttributes overriddenAttributtes = this.strategy.override(ANNOTATION_CLASS, IMPORT_OPTIONAL_ATTRIBUTTES, null);
+        assertEquals(IMPORT_OPTIONAL_ATTRIBUTTES.getClass(FACTORY_ATTRIBUTE_NAME), overriddenAttributtes.getClass(FACTORY_ATTRIBUTE_NAME));
+    }
+
+    @Test
+    public void testGetConfigurationProperties() {
+        String propertyNamePrefix = this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS);
+
+        environment.setProperty(propertyNamePrefix + "a", "1");
+        environment.setProperty(propertyNamePrefix + "b", "2");
+        environment.setProperty(propertyNamePrefix + "c", "3");
+
+        Map<String, Object> configurationProperties = this.strategy.getConfigurationProperties(ANNOTATION_CLASS);
+        assertEquals(3, configurationProperties.size());
+        assertEquals("1", configurationProperties.get("a"));
+        assertEquals("2", configurationProperties.get("b"));
+        assertEquals("3", configurationProperties.get("c"));
+        assertNull(configurationProperties.get("annotationType"));
+    }
+
+    @Test
+    public void testGetPropertyNamePrefix() {
+        String prefixPropertyName = getPrefixPropertyName(ANNOTATION_CLASS);
+        this.environment.setProperty(prefixPropertyName, "ms");
+        assertEquals("ms.", this.strategy.getPropertyNamePrefix(ANNOTATION_CLASS));
+    }
+
+    @Test
+    public void testGetPrefixPropertyName() {
+        String prefixPropertyName = getPrefixPropertyName(ANNOTATION_CLASS);
+        assertEquals("microsphere.spring.prefix." + ANNOTATION_CLASS.getName(), prefixPropertyName);
+    }
+
+    @Test
+    public void testGetDefaultPropertyNamePrefix() {
+        String defaultPropertyNamePrefix = getDefaultPropertyNamePrefix(ANNOTATION_CLASS);
+        assertEquals("microsphere.spring.prefix.PropertySource.", defaultPropertyNamePrefix);
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ImportOptionalTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/ImportOptionalTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.spring.test.domain.User;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * {@link ImportOptional} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ImportOptional
+ * @since 1.0.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {
+        ImportOptionalTest.class
+})
+@TestPropertySource(properties = {
+        "microsphere.spring.prefix.ImportOptional.value=io.microsphere.spring.test.domain.User"
+})
+@ImportOptional(value = {
+        "overridden.here",
+})
+public class ImportOptionalTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void test() {
+        assertNotNull(this.context.getBean(User.class));
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/AnnotationUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/AnnotationUtilsTest.java
@@ -26,6 +26,7 @@ import static io.microsphere.spring.core.annotation.AnnotationUtils.getAttribute
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getAttributes;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getRequiredAttribute;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.isPresent;
+import static io.microsphere.spring.core.annotation.AnnotationUtils.ofAnnotationAttributes;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.tryGetMergedAnnotation;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.tryGetMergedAnnotationAttributes;
 import static io.microsphere.spring.util.SpringVersionUtils.SPRING_CONTEXT_VERSION;
@@ -43,6 +44,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.beans.factory.annotation.Autowire.NO;
@@ -393,6 +395,24 @@ public class AnnotationUtilsTest {
     @Test
     public void testFindAnnotationTypeWithNull() {
         assertNull(findAnnotationType(null));
+    }
+
+    @Test
+    public void testOfAnnotationAttributes() {
+        AnnotationAttributes annotationAttributes = ofAnnotationAttributes(defaultAttributeValuesOfBean);
+        assertEquals(annotationAttributes, defaultAttributeValuesOfBean);
+    }
+
+    @Test
+    public void testOfAnnotationAttributesOnNull() {
+        AnnotationAttributes annotationAttributes = ofAnnotationAttributes(null);
+        assertTrue(annotationAttributes.isEmpty());
+    }
+
+    @Test
+    public void testOfAnnotationAttributesOnAnnotationAttributes() {
+        AnnotationAttributes annotationAttributes = ofAnnotationAttributes(defaultAttributeValuesOfBean);
+        assertSame(annotationAttributes, ofAnnotationAttributes(annotationAttributes));
     }
 
     private <A extends Annotation> A getAnnotation(String methodName, Class<A> annotationClass) {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.core.annotation;
 
+import io.microsphere.collection.SetUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,10 +24,20 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.spring.core.annotation.GenericAnnotationAttributes.of;
+import static io.microsphere.spring.core.annotation.GenericAnnotationAttributes.ofSet;
+import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.core.annotation.AnnotationUtils.getAnnotationAttributes;
 
 /**
@@ -58,6 +69,36 @@ public class GenericAnnotationAttributesTest {
     public void testOfWithAnnotationAttributes() {
         GenericAnnotationAttributes attributes = of(this.attributes);
         assertAttributes(attributes, contextConfiguration);
+
+        AnnotationAttributes annotationAttributes = newAnnotationAttributes();
+        attributes = of(annotationAttributes);
+        assertAttributes(attributes, contextConfiguration);
+    }
+
+    @Test
+    public void testOfWithMapAndAnnotationType() {
+        GenericAnnotationAttributes attributes = of(getAnnotationAttributes(this.contextConfiguration), ContextConfiguration.class);
+        assertAttributes(attributes, contextConfiguration);
+
+        attributes = of(this.attributes, ContextConfiguration.class);
+        assertAttributes(attributes, contextConfiguration);
+    }
+
+    @Test
+    public void testOnInvalidConstructorArgument() {
+        assertThrows(IllegalArgumentException.class, () -> of((Annotation) null));
+        assertThrows(IllegalArgumentException.class, () -> of(new AnnotationAttributes()));
+        assertThrows(NullPointerException.class, () -> of(null, null));
+        assertThrows(IllegalArgumentException.class, () -> of(newHashMap(), null));
+    }
+
+    @Test
+    public void testOfSet() {
+        Set<AnnotationAttributes> annotationAttributesSet = ofSet();
+        assertTrue(annotationAttributesSet.isEmpty());
+
+        annotationAttributesSet = ofSet(this.attributes);
+        assertEquals(SetUtils.of(this.attributes), annotationAttributesSet);
     }
 
     @Test
@@ -69,6 +110,34 @@ public class GenericAnnotationAttributesTest {
     public void testEquals() {
         AnnotationAttributes annotationAttributes = (AnnotationAttributes) getAnnotationAttributes(this.contextConfiguration);
         assertEquals(this.attributes, annotationAttributes);
+    }
+
+    @Test
+    public void testEqualsOnNotAnnotationAttributes() {
+        assertNotEquals(this.attributes, emptyMap());
+    }
+
+    @Test
+    public void testEqualsOnDifferentAnnotationType() {
+        assertNotEquals(this.attributes, new AnnotationAttributes());
+    }
+
+    @Test
+    public void testEqualsOnDifferentSize() {
+        AnnotationAttributes annotationAttributes = newAnnotationAttributes();
+        GenericAnnotationAttributes attributes = of(annotationAttributes);
+        attributes.put("a", "1");
+
+        assertNotEquals(this.attributes, attributes);
+    }
+
+    @Test
+    public void testEqualsOnDifferentEntry() {
+        AnnotationAttributes annotationAttributes = newAnnotationAttributes();
+        GenericAnnotationAttributes attributes = of(annotationAttributes);
+        attributes.put("name", "test");
+
+        assertNotEquals(this.attributes, attributes);
     }
 
     @Test
@@ -87,5 +156,11 @@ public class GenericAnnotationAttributesTest {
         assertEquals(contextConfiguration.inheritInitializers(), attributes.getBoolean("inheritInitializers"));
         assertEquals(contextConfiguration.inheritLocations(), attributes.getBoolean("inheritLocations"));
         assertArrayEquals(contextConfiguration.value(), attributes.getStringArray("value"));
+    }
+
+    AnnotationAttributes newAnnotationAttributes() {
+        AnnotationAttributes annotationAttributes = new AnnotationAttributes(this.attributes.annotationType().getName(), getDefaultClassLoader());
+        annotationAttributes.putAll(this.attributes);
+        return annotationAttributes;
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
@@ -86,7 +86,6 @@ public class GenericAnnotationAttributesTest {
 
     @Test
     public void testOnInvalidConstructorArgument() {
-        assertThrows(IllegalArgumentException.class, () -> of((Annotation) null));
         assertThrows(IllegalArgumentException.class, () -> of(new AnnotationAttributes()));
         assertThrows(NullPointerException.class, () -> of(null, null));
         assertThrows(IllegalArgumentException.class, () -> of(newHashMap(), null));

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
@@ -103,6 +103,7 @@ public class GenericAnnotationAttributesTest {
 
     @Test
     public void testHashCode() {
+        this.attributes.put("a", null);
         assertEquals(this.attributes.hashCode(), of(this.attributes).hashCode());
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/ResolvablePlaceholderAnnotationAttributesTest.java
@@ -56,14 +56,34 @@ public class ResolvablePlaceholderAnnotationAttributesTest {
     }
 
     @Test
+    public void testOfWithGenericAnnotationAttributes() {
+        Map<String, Object> map = ofMap("value", ofArray("1", "2"));
+        GenericAnnotationAttributes attributes = new GenericAnnotationAttributes(map, ConstructorProperties.class);
+        ResolvablePlaceholderAnnotationAttributes annotationAttributes = of(attributes);
+        assertResolvablePlaceholderAnnotationAttributes(annotationAttributes);
+
+        annotationAttributes = of(annotationAttributes);
+        assertResolvablePlaceholderAnnotationAttributes(annotationAttributes);
+    }
+
+    @Test
+    public void testOfWithGenericAnnotationAttributesAndPropertyResolver() {
+        Map<String, Object> map = ofMap("value", ofArray("${a}", "${b}"));
+        GenericAnnotationAttributes attributes = new GenericAnnotationAttributes(map, ConstructorProperties.class);
+        ResolvablePlaceholderAnnotationAttributes annotationAttributes = of(attributes, this.environment);
+        assertResolvablePlaceholderAnnotationAttributes(annotationAttributes);
+
+        annotationAttributes = of(annotationAttributes, this.environment);
+        assertResolvablePlaceholderAnnotationAttributes(annotationAttributes);
+    }
+
+    @Test
     public void testOfWithAnnotation() {
         ConstructorProperties constructorProperties = findConstructor(getClass()).getAnnotation(ConstructorProperties.class);
         ResolvablePlaceholderAnnotationAttributes annotationAttributes = of(constructorProperties, environment);
         assertEquals(ConstructorProperties.class, annotationAttributes.annotationType());
         assertEquals(constructorProperties.annotationType(), annotationAttributes.annotationType());
-        String[] values = annotationAttributes.getStringArray("value");
-        assertEquals("1", values[0]);
-        assertEquals("2", values[1]);
+        assertResolvablePlaceholderAnnotationAttributes(annotationAttributes);
     }
 
     @Test
@@ -106,6 +126,12 @@ public class ResolvablePlaceholderAnnotationAttributesTest {
         assertEquals(2, attributes.size());
         assertEquals("1", attributes.getString("a"));
         assertEquals("2", attributes.getString("b"));
+    }
+
+    private void assertResolvablePlaceholderAnnotationAttributes(ResolvablePlaceholderAnnotationAttributes attributes) {
+        String[] values = attributes.getStringArray("value");
+        assertEquals("1", values[0]);
+        assertEquals("2", values[1]);
     }
 
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/PropertiesUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/PropertiesUtilsTest.java
@@ -18,11 +18,13 @@
 package io.microsphere.spring.core.io.support;
 
 import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.io.IOException;
 import java.util.Properties;
 
 import static io.microsphere.spring.core.io.support.PropertiesUtils.loadProperties;
+import static io.microsphere.util.ArrayUtils.ofArray;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -47,6 +49,16 @@ public class PropertiesUtilsTest {
     @Test
     public void testLoadPropertiesOnTextBlock() throws IOException {
         Properties properties = loadProperties(PROPERTIES);
+        assertProperties(properties);
+    }
+
+    @Test
+    public void testLoadPropertiesWithPropertyResolver() throws IOException {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("a", "1");
+        environment.setProperty("b", "2");
+        environment.setProperty("c", "3");
+        Properties properties = loadProperties(ofArray("a=${a}", "b=${b}", "c ${c}"), environment);
         assertProperties(properties);
     }
 

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/PropertiesUtilsTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/io/support/PropertiesUtilsTest.java
@@ -20,7 +20,6 @@ package io.microsphere.spring.core.io.support;
 import org.junit.Test;
 import org.springframework.mock.env.MockEnvironment;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import static io.microsphere.spring.core.io.support.PropertiesUtils.loadProperties;
@@ -41,19 +40,19 @@ public class PropertiesUtilsTest {
             "            c 3";
 
     @Test
-    public void testLoadProperties() throws IOException {
+    public void testLoadProperties() {
         Properties properties = loadProperties("a=1", "b : 2", "c 3");
         assertProperties(properties);
     }
 
     @Test
-    public void testLoadPropertiesOnTextBlock() throws IOException {
+    public void testLoadPropertiesOnTextBlock() {
         Properties properties = loadProperties(PROPERTIES);
         assertProperties(properties);
     }
 
     @Test
-    public void testLoadPropertiesWithPropertyResolver() throws IOException {
+    public void testLoadPropertiesWithPropertyResolver() {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("a", "1");
         environment.setProperty("b", "2");

--- a/microsphere-spring-test/pom.xml
+++ b/microsphere-spring-test/pom.xml
@@ -127,6 +127,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- H2 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Apache Tomcat -->
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>

--- a/microsphere-spring-test/src/main/java/io/microsphere/spring/test/jdbc/embedded/EmbeddedDataBaseBeanDefinitionRegistrar.java
+++ b/microsphere-spring-test/src/main/java/io/microsphere/spring/test/jdbc/embedded/EmbeddedDataBaseBeanDefinitionRegistrar.java
@@ -61,6 +61,9 @@ class EmbeddedDataBaseBeanDefinitionRegistrar implements ImportBeanDefinitionReg
             case SQLITE:
                 processSQLite(attributes, registry);
                 break;
+            case H2:
+                processH2(attributes, registry);
+                break;
         }
     }
 
@@ -75,9 +78,18 @@ class EmbeddedDataBaseBeanDefinitionRegistrar implements ImportBeanDefinitionReg
         registerSQLiteDataSourceBeanDefinition(attributes, registry);
     }
 
+    private void processH2(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
+        registerH2DataSourceBeanDefinition(attributes, registry);
+    }
+
     private void registerSQLiteDataSourceBeanDefinition(AnnotationAttributes attributes,
                                                         BeanDefinitionRegistry registry) {
         registerDataSourceBeanDefinition("jdbc:sqlite::memory:", attributes, registry);
+    }
+
+    private void registerH2DataSourceBeanDefinition(AnnotationAttributes attributes,
+                                                    BeanDefinitionRegistry registry) {
+        registerDataSourceBeanDefinition("jdbc:h2:mem:", attributes, registry);
     }
 
     private void registerDataSourceBeanDefinition(String jdbcURL,

--- a/microsphere-spring-test/src/main/java/io/microsphere/spring/test/jdbc/embedded/EmbeddedDatabaseType.java
+++ b/microsphere-spring-test/src/main/java/io/microsphere/spring/test/jdbc/embedded/EmbeddedDatabaseType.java
@@ -25,5 +25,13 @@ package io.microsphere.spring.test.jdbc.embedded;
  */
 public enum EmbeddedDatabaseType {
 
-    SQLITE
+    /**
+     * SQLite
+     */
+    SQLITE,
+
+    /**
+     * H2
+     */
+    H2
 }

--- a/microsphere-spring-test/src/test/java/io/microsphere/spring/test/jdbc/embedded/EnableEmbeddedDatabasesTest.java
+++ b/microsphere-spring-test/src/test/java/io/microsphere/spring/test/jdbc/embedded/EnableEmbeddedDatabasesTest.java
@@ -29,6 +29,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static io.microsphere.spring.test.jdbc.embedded.EmbeddedDatabaseType.H2;
+
 /**
  * {@link EnableEmbeddedDatabases} Test
  *
@@ -38,7 +40,7 @@ import java.sql.Statement;
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = EnableEmbeddedDatabasesTest.class)
 @EnableEmbeddedDatabase(dataSource = "primary", primary = true)
-@EnableEmbeddedDatabase(dataSource = "secondary")
+@EnableEmbeddedDatabase(dataSource = "secondary", type = H2)
 public class EnableEmbeddedDatabasesTest {
 
     @Autowired

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
@@ -49,7 +49,8 @@ import static io.microsphere.spring.web.method.support.DelegatingHandlerMethodAd
  * @see EnableWebExtension
  * @since 1.0.0
  */
-public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension> implements ImportBeanDefinitionRegistrar {
+public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension>
+        implements ImportBeanDefinitionRegistrar {
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
@@ -17,7 +17,7 @@
 package io.microsphere.spring.web.annotation;
 
 import io.microsphere.spring.beans.BeanSource;
-import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.event.WebEventPublisher;
 import io.microsphere.spring.web.metadata.CompositeWebEndpointMappingRegistry;
@@ -49,12 +49,12 @@ import static io.microsphere.spring.web.method.support.DelegatingHandlerMethodAd
  * @see EnableWebExtension
  * @since 1.0.0
  */
-public class WebExtensionBeanDefinitionRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
+public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension> implements ImportBeanDefinitionRegistrar {
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
 
-        ResolvablePlaceholderAnnotationAttributes<EnableWebExtension> attributes = getAnnotationAttributes(metadata, EnableWebExtension.class);
+        ResolvablePlaceholderAnnotationAttributes<EnableWebExtension> attributes = getAnnotationAttributes(metadata);
 
         BeanSource[] sources = (BeanSource[]) attributes.get("sources");
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/EnableWebFluxExtension.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/EnableWebFluxExtension.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.webflux.annotation;
 
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.event.HandlerMethodArgumentsResolvedEvent;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
@@ -70,8 +71,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(TYPE)
 @Documented
-@Import(WebFluxExtensionBeanDefinitionRegistrar.class)
 @EnableWebExtension
+@OverrideAnnotationAttributes
+@Import(WebFluxExtensionBeanDefinitionRegistrar.class)
 public @interface EnableWebFluxExtension {
 
     /**

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
@@ -17,7 +17,8 @@
 
 package io.microsphere.spring.webflux.annotation;
 
-import io.microsphere.logging.Logger;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
 import io.microsphere.spring.web.util.RequestContextStrategy;
 import io.microsphere.spring.webflux.handler.ReversedProxyHandlerMapping;
 import io.microsphere.spring.webflux.metadata.HandlerMappingWebEndpointMappingResolver;
@@ -33,10 +34,8 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.config.BeanDefinitionUtils.genericBeanDefinition;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static org.springframework.util.StringUtils.uncapitalize;
 
 /**
@@ -44,20 +43,17 @@ import static org.springframework.util.StringUtils.uncapitalize;
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see EnableWebFluxExtension
+ * @see OverrideAnnotationAttributes
+ * @see AnnotatedBeanCapableImportCandidate
  * @see ImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-class WebFluxExtensionBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar {
-
-    private static final Logger logger = getLogger(WebFluxExtensionBeanDefinitionRegistrar.class);
-
-    public static final Class<EnableWebFluxExtension> ANNOTATION_CLASS = EnableWebFluxExtension.class;
-
-    public static final String ANNOTATION_CLASS_NAME = ANNOTATION_CLASS.getName();
+class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebFluxExtension>
+        implements ImportBeanDefinitionRegistrar {
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes attributes = getAttributes(metadata);
+        AnnotationAttributes attributes = getAnnotationAttributes(metadata);
 
         registerWebEndpointMappingResolver(attributes, registry);
 
@@ -146,10 +142,6 @@ class WebFluxExtensionBeanDefinitionRegistrar implements ImportBeanDefinitionReg
             registerBeanDefinition(registry, ReversedProxyHandlerMapping.class);
         }
         log("@EnableWebFluxExtension.reversedProxyHandlerMapping() = {}", reversedProxyHandlerMapping);
-    }
-
-    private AnnotationAttributes getAttributes(AnnotationMetadata metadata) {
-        return getAnnotationAttributes(metadata, ANNOTATION_CLASS_NAME);
     }
 
     private void log(String messagePattern, Object... args) {

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.webmvc.annotation;
 
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.event.HandlerMethodArgumentsResolvedEvent;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
@@ -77,11 +78,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(TYPE)
 @Documented
+@EnableWebExtension
+@OverrideAnnotationAttributes
 @Import(value = {
         WebMvcExtensionBeanDefinitionRegistrar.class,
         WebMvcExtensionConfiguration.class
 })
-@EnableWebExtension
 public @interface EnableWebMvcExtension {
 
     /**

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.webmvc.annotation;
 
-import io.microsphere.logging.Logger;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.annotation.WebExtensionBeanDefinitionRegistrar;
 import io.microsphere.spring.web.metadata.ServletWebEndpointMappingResolver;
@@ -33,9 +33,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static io.microsphere.spring.webmvc.interceptor.LazyCompositeHandlerInterceptor.BEAN_NAME;
 import static io.microsphere.util.ArrayUtils.arrayEquals;
 import static io.microsphere.util.ArrayUtils.isNotEmpty;
@@ -51,20 +49,15 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * @see WebExtensionBeanDefinitionRegistrar
  * @since 1.0.0
  */
-public class WebMvcExtensionBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar {
-
-    private static final Logger logger = getLogger(WebMvcExtensionBeanDefinitionRegistrar.class);
-
-    public static final Class<EnableWebMvcExtension> ANNOTATION_CLASS = EnableWebMvcExtension.class;
-
-    public static final String ANNOTATION_CLASS_NAME = ANNOTATION_CLASS.getName();
+public class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension>
+        implements ImportBeanDefinitionRegistrar {
 
     private static final Class<? extends HandlerInterceptor>[] ALL_HANDLER_INTERCEPTOR_CLASSES = ofArray(HandlerInterceptor.class);
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
 
-        AnnotationAttributes attributes = getAttributes(metadata);
+        AnnotationAttributes attributes = getAnnotationAttributes(metadata);
 
         registerWebEndpointMappingResolvers(attributes, registry);
 
@@ -158,10 +151,6 @@ public class WebMvcExtensionBeanDefinitionRegistrar implements ImportBeanDefinit
             registerBeanDefinition(registry, ReversedProxyHandlerMapping.class);
         }
         log("@EnableWebMvcExtension.reversedProxyHandlerMapping() = {}", reversedProxyHandlerMapping);
-    }
-
-    private AnnotationAttributes getAttributes(AnnotationMetadata metadata) {
-        return getAnnotationAttributes(metadata, ANNOTATION_CLASS_NAME);
     }
 
     private void log(String messagePattern, Object... args) {


### PR DESCRIPTION
This pull request introduces a new mechanism for overriding annotation attributes in Spring-based applications using configuration properties, along with several supporting enhancements and documentation improvements. The main focus is to allow annotation attributes to be dynamically configured via external properties, increasing flexibility and configurability for annotation-driven components.

Key changes include:

**Annotation Attribute Override Mechanism:**

* Added a new interface and strategy class, `ConfigurationPropertyOverrideAnnotationAttributesStrategy`, which enables overriding annotation attributes with values from the Spring `Environment` (e.g., `application.properties`). This strategy determines property prefixes, maps properties to annotation attributes, and performs type conversion.
* Modified `BeanCapableImportCandidate` to support the new override mechanism by checking for the `@OverrideAnnotationAttributes` meta-annotation. If present, it instantiates and initializes the specified override strategy, applying it to annotation attributes.
* Annotated `ImportOptional` with `@OverrideAnnotationAttributes` to enable property-based attribute overrides for this annotation.

**Constants and Utility Enhancements:**

* Added a new constant, `PREFIX_PROPERTY_NAME_PREFIX`, to `PropertyConstants`, standardizing the prefix used for configuration property overrides.
* Introduced a utility method, `initializeBean`, in `BeanUtils` to simulate the Spring bean initialization lifecycle for arbitrary objects, used internally by the override strategy mechanism.

**Codebase Improvements and Maintenance:**

* Added new imports and static imports to support the override mechanism and bean initialization. [[1]](diffhunk://#diff-73a7fd4a9c71419911955d4ff1545da864a86144407a58fa28130e2d0b5a3077R41) [[2]](diffhunk://#diff-73a7fd4a9c71419911955d4ff1545da864a86144407a58fa28130e2d0b5a3077R51-R61)
* Improved documentation and references, including a new `@see` reference for `OverrideAnnotationAttributes` in `BeanCapableImportCandidate`.
* Minor formatting and import adjustments for clarity and maintainability.

These changes collectively provide a robust and extensible way to externalize annotation configuration, making it easier to adapt applications to different environments and requirements.

**References:** [[1]](diffhunk://#diff-898fdfae87778c3f4cf8546de32962d333f3858f0d6170d597d7c0a700932aaeR1-R295) [[2]](diffhunk://#diff-73a7fd4a9c71419911955d4ff1545da864a86144407a58fa28130e2d0b5a3077L274-R323) [[3]](diffhunk://#diff-99f235ea262e1ba64516557d36e5e2ca6e75d60e9f913d3607da537fd19da978R49) [[4]](diffhunk://#diff-1529e60c14be24b3e5dc6a9473b599864ec2bf971a09c79414f957d408be6204R35-R39) [[5]](diffhunk://#diff-d8139c1e5de0e02e0d9b0a90fb595daef3b9d83f05b44bb897ff8f0abbf890e9R610-R640)