### PR TITLE
Refactor WebMvcConfigurer and enhance BeanDefinition registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.25         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.25         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.26         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.26         |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingPostProcessor.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingPostProcessor.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
-import static io.microsphere.spring.beans.factory.annotation.ConfigurationBeanBindingRegistrar.ENABLE_CONFIGURATION_BINDING_CLASS;
 import static java.util.Collections.unmodifiableList;
 import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;
 import static org.springframework.core.annotation.AnnotationAwareOrderComparator.sort;
@@ -168,7 +167,8 @@ public class ConfigurationBeanBindingPostProcessor implements BeanPostProcessor,
     }
 
     private boolean isConfigurationBean(Object bean, BeanDefinition beanDefinition) {
-        return beanDefinition != null && ENABLE_CONFIGURATION_BINDING_CLASS.equals(beanDefinition.getSource()) && nullSafeEquals(getBeanClassName(bean), beanDefinition.getBeanClassName());
+        return beanDefinition != null && EnableConfigurationBeanBinding.class.equals(beanDefinition.getSource())
+                && nullSafeEquals(getBeanClassName(bean), beanDefinition.getBeanClassName());
     }
 
     private String getBeanClassName(Object bean) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
@@ -16,18 +16,13 @@
  */
 package io.microsphere.spring.beans.factory.annotation;
 
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.beans.factory.support.ConfigurationBeanAliasGenerator;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.type.AnnotationMetadata;
@@ -39,7 +34,6 @@ import java.util.Set;
 import static io.microsphere.collection.SetUtils.newLinkedHashSet;
 import static io.microsphere.collection.Sets.ofSet;
 import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.factory.annotation.ConfigurationBeanBindingPostProcessor.BEAN_NAME;
 import static io.microsphere.spring.beans.factory.annotation.ConfigurationBeanBindingPostProcessor.initBeanMetadataAttributes;
 import static io.microsphere.spring.beans.factory.annotation.EnableConfigurationBeanBinding.DEFAULT_IGNORE_INVALID_FIELDS;
@@ -49,7 +43,6 @@ import static io.microsphere.spring.beans.factory.support.BeanRegistrar.register
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerInfrastructureBean;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getAttribute;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getRequiredAttribute;
-import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
 import static io.microsphere.spring.core.env.PropertySourcesUtils.getSubProperties;
 import static io.microsphere.spring.core.env.PropertySourcesUtils.normalizePrefix;
 import static io.microsphere.spring.core.io.support.SpringFactoriesLoaderUtils.loadFactories;
@@ -98,25 +91,13 @@ import static org.springframework.util.StringUtils.hasText;
  * @see ConfigurationBeanBindingPostProcessor
  * @since 1.0.0
  */
-public class ConfigurationBeanBindingRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware,
-        BeanFactoryAware {
-
-    final static Class ENABLE_CONFIGURATION_BINDING_CLASS = EnableConfigurationBeanBinding.class;
-
-    private final static String ENABLE_CONFIGURATION_BINDING_CLASS_NAME = ENABLE_CONFIGURATION_BINDING_CLASS.getName();
-
-    private final Logger logger = getLogger(getClass());
-
-    private ConfigurableEnvironment environment;
-
-    private BeanFactory beanFactory;
+class ConfigurationBeanBindingRegistrar extends AnnotatedBeanCapableImportCandidate<EnableConfigurationBeanBinding> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-
-        Map<String, Object> attributes = metadata.getAnnotationAttributes(ENABLE_CONFIGURATION_BINDING_CLASS_NAME);
-
-        registerConfigurationBeanDefinitions(attributes, registry);
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableConfigurationBeanBinding> annotationAttributes) {
+        registerConfigurationBeanDefinitions(annotationAttributes, registry);
     }
 
     public void registerConfigurationBeanDefinitions(Map<String, Object> attributes, BeanDefinitionRegistry registry) {
@@ -198,16 +179,11 @@ public class ConfigurationBeanBindingRegistrar implements ImportBeanDefinitionRe
     }
 
     private void setSource(AbstractBeanDefinition beanDefinition) {
-        beanDefinition.setSource(ENABLE_CONFIGURATION_BINDING_CLASS);
+        beanDefinition.setSource(getAnnotationType());
     }
 
     private void registerConfigurationBindingBeanPostProcessor(BeanDefinitionRegistry registry) {
         registerInfrastructureBean(registry, BEAN_NAME, ConfigurationBeanBindingPostProcessor.class);
-    }
-
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.environment = asConfigurableEnvironment(environment);
     }
 
     private Set<String> resolveMultipleBeanNames(Map<String, Object> properties) {
@@ -243,10 +219,5 @@ public class ConfigurationBeanBindingRegistrar implements ImportBeanDefinitionRe
 
         return beanName;
 
-    }
-
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        this.beanFactory = beanFactory;
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
@@ -16,16 +16,13 @@
  */
 package io.microsphere.spring.beans.factory.annotation;
 
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.context.EnvironmentAware;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
-
-import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
-import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
 
 /**
  * The {@link ImportBeanDefinitionRegistrar Registrar class} for {@link EnableConfigurationBeanBindings}
@@ -33,28 +30,19 @@ import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvi
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
  */
-public class ConfigurationBeanBindingsRegister implements ImportBeanDefinitionRegistrar, EnvironmentAware {
-
-    private ConfigurableEnvironment environment;
+class ConfigurationBeanBindingsRegister extends AnnotatedBeanCapableImportCandidate<EnableConfigurationBeanBindings> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-
-        AnnotationAttributes attributes = getAnnotationAttributes(metadata, EnableConfigurationBeanBindings.class);
-
-        AnnotationAttributes[] annotationAttributes = attributes.getAnnotationArray("value");
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableConfigurationBeanBindings> annotationAttributes) {
 
         ConfigurationBeanBindingRegistrar registrar = new ConfigurationBeanBindingRegistrar();
 
-        registrar.setEnvironment(environment);
+        registrar.setEnvironment(getEnvironment());
 
-        for (AnnotationAttributes element : annotationAttributes) {
-            registrar.registerConfigurationBeanDefinitions(element, registry);
+        for (AnnotationAttributes attributes : annotationAttributes.getAnnotationArray("value")) {
+            registrar.registerConfigurationBeanDefinitions(attributes, registry);
         }
-    }
-
-    @Override
-    public void setEnvironment(Environment environment) {
-        this.environment = asConfigurableEnvironment(environment);
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/support/BeanRegistrar.java
@@ -451,6 +451,35 @@ public abstract class BeanRegistrar {
     }
 
     /**
+     * Registers a {@link BeanDefinition} into the given registry.
+     * <p>
+     * This method delegates to {@link #registerBeanDefinition(BeanDefinitionRegistry, String, BeanDefinition)}
+     * with a {@code null} bean name, causing a unique bean name to be generated automatically based on the
+     * provided bean definition. The registration process respects the default bean overriding settings of the registry.
+     * If the bean is successfully registered, it returns {@code true}; otherwise, it returns {@code false}.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * BeanDefinition beanDefinition = genericBeanDefinition(MyService.class);
+     * boolean registered = registerBeanDefinition(registry, beanDefinition);
+     *
+     * if (registered) {
+     *     System.out.println("Bean registered successfully with auto-generated name.");
+     * } else {
+     *     System.out.println("Bean was already registered.");
+     * }
+     * }</pre>
+     *
+     * @param registry       The {@link BeanDefinitionRegistry} where the bean will be registered.
+     * @param beanDefinition The bean definition to register.
+     * @return Returns {@code true} if the bean is registered for the first time; returns {@code false} if it was already registered.
+     */
+    public static boolean registerBeanDefinition(BeanDefinitionRegistry registry, BeanDefinition beanDefinition) {
+        return registerBeanDefinition(registry, null, beanDefinition);
+    }
+
+    /**
      * Registers a {@link BeanDefinition} with an optional name into the given registry.
      * <p>
      * This method attempts to register the provided bean definition. If a bean name is provided,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
@@ -29,6 +29,7 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -65,21 +66,20 @@ import static org.springframework.util.StringUtils.hasText;
  * @see ImportSelector
  * @since 1.0.0
  */
-public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extends AnnotatedBeanCapableImportCandidate<A>
-        implements ImportSelector {
+public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extends AnnotatedBeanCapableImportCandidate<A> {
 
     protected static final String NAME_ATTRIBUTE_NAME = "name";
 
     private String propertySourceName;
 
     @Override
-    public final String[] selectImports(AnnotationMetadata metadata) {
-        ResolvablePlaceholderAnnotationAttributes attributes = getAnnotationAttributes(metadata);
-        String propertySourceName = resolvePropertySourceName(attributes, metadata);
+    public final void selectImports(AnnotationMetadata metadata, ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
+                                    Set<String> imports) {
+        String propertySourceName = resolvePropertySourceName(annotationAttributes, metadata);
         this.propertySourceName = propertySourceName;
         MutablePropertySources propertySources = getEnvironment().getPropertySources();
         try {
-            loadPropertySource(attributes, metadata, propertySourceName, propertySources);
+            loadPropertySource(annotationAttributes, metadata, propertySourceName, propertySources);
         } catch (Throwable e) {
             String errorMessage = "The Configuration bean[class : '" + metadata.getClassName() + "', annotated : @" + annotationType.getName() + "] can't load the PropertySource[name : '" + propertySourceName + "']";
             if (logger.isErrorEnabled()) {
@@ -87,7 +87,6 @@ public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extend
             }
             throw new BeanCreationException(errorMessage, e);
         }
-        return NO_CLASS_TO_IMPORT;
     }
 
     /**

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
@@ -22,7 +22,6 @@ import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandid
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
@@ -34,7 +33,7 @@ import java.util.Set;
 import static org.springframework.util.StringUtils.hasText;
 
 /**
- * Abstract base class for {@link ImportSelector} implementations that load a {@link PropertySource}
+ * Abstract base class implementations that load a {@link PropertySource}
  * when a {@link Configuration} class is annotated with a specific annotation.
  *
  * <p>This class provides a foundation for conditionally adding property sources to the Spring environment
@@ -63,7 +62,6 @@ import static org.springframework.util.StringUtils.hasText;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see ResourcePropertySourceLoader
  * @see PropertySourceExtensionLoader
- * @see ImportSelector
  * @since 1.0.0
  */
 public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extends AnnotatedBeanCapableImportCandidate<A> {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
@@ -17,8 +17,8 @@
 package io.microsphere.spring.config.context.annotation;
 
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.core.env.PropertySourcesUtils;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -28,6 +28,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static io.microsphere.lang.function.ThrowableAction.execute;
 import static io.microsphere.spring.core.env.PropertySourcesUtils.DEFAULT_PROPERTIES_PROPERTY_SOURCE_NAME;
@@ -47,8 +48,9 @@ class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCa
         implements ImportBeanDefinitionRegistrar {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes annotationAttributes = getAnnotationAttributes(metadata);
+    protected void selectImports(AnnotationMetadata metadata,
+                                 ResolvablePlaceholderAnnotationAttributes<DefaultPropertiesPropertySource> annotationAttributes,
+                                 Set<String> imports) {
         loadPropertySource(annotationAttributes);
     }
 
@@ -86,7 +88,7 @@ class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCa
 
     void loadPropertySource(PropertySource<?> propertySource, Map<String, Object> defaultProperties) {
         if (propertySource instanceof EnumerablePropertySource) {
-            EnumerablePropertySource enumerablePropertySource = (EnumerablePropertySource) propertySource;
+            EnumerablePropertySource<?> enumerablePropertySource = (EnumerablePropertySource<?>) propertySource;
             for (String propertyName : enumerablePropertySource.getPropertyNames()) {
                 Object propertyValue = propertySource.getProperty(propertyName);
                 defaultProperties.put(propertyName, propertyValue);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
@@ -19,7 +19,6 @@ package io.microsphere.spring.config.context.annotation;
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.core.env.PropertySourcesUtils;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
@@ -44,8 +43,7 @@ import static io.microsphere.util.ArrayUtils.isEmpty;
  * @see ResourcePropertySourceLoader
  * @since 1.0.0
  */
-class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySource>
-        implements ImportBeanDefinitionRegistrar {
+class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySource> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
@@ -18,7 +18,6 @@ package io.microsphere.spring.config.context.annotation;
 
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.type.AnnotationMetadata;
@@ -37,8 +36,7 @@ import static io.microsphere.spring.core.annotation.GenericAnnotationAttributes.
  * @see AnnotatedPropertySourceLoader
  * @since 1.0.0
  */
-class DefaultPropertiesPropertySourcesLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySources>
-        implements ImportBeanDefinitionRegistrar {
+class DefaultPropertiesPropertySourcesLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySources> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
@@ -17,7 +17,7 @@
 package io.microsphere.spring.config.context.annotation;
 
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.PropertySource;
@@ -41,11 +41,10 @@ class DefaultPropertiesPropertySourcesLoader extends AnnotatedBeanCapableImportC
         implements ImportBeanDefinitionRegistrar {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-
-        AnnotationAttributes attributes = getAnnotationAttributes(metadata);
-
-        AnnotationAttributes[] annotationAttributesArray = attributes.getAnnotationArray("value");
+    protected void selectImports(AnnotationMetadata metadata,
+                                 ResolvablePlaceholderAnnotationAttributes<DefaultPropertiesPropertySources> annotationAttributes,
+                                 Set<String> imports) {
+        AnnotationAttributes[] annotationAttributesArray = annotationAttributes.getAnnotationArray("value");
 
         Set<AnnotationAttributes> attributesSet = ofSet(annotationAttributesArray);
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/PropertySourceExtensionLoader.java
@@ -22,7 +22,6 @@ import io.microsphere.spring.config.env.event.PropertySourceChangedEvent;
 import io.microsphere.spring.config.env.event.PropertySourcesChangedEvent;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -60,7 +59,7 @@ import static org.springframework.util.Assert.notNull;
 import static org.springframework.util.StringUtils.hasText;
 
 /**
- * Abstract {@link ImportSelector} class to load the {@link PropertySource PropertySource}
+ * Abstract class to load the {@link PropertySource PropertySource}
  * when the {@link Configuration configuration} annotated the Enable annotation that meta-annotates {@link PropertySourceExtension @PropertySourceExtension}
  *
  * @param <A>  The type of {@link Annotation} must meta-annotate {@link PropertySourceExtension}
@@ -68,7 +67,6 @@ import static org.springframework.util.StringUtils.hasText;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see PropertySourceExtension
  * @see PropertySourceExtensionAttributes
- * @see ImportSelector
  * @since 1.0.0
  */
 public abstract class PropertySourceExtensionLoader<A extends Annotation, EA extends PropertySourceExtensionAttributes<A>>

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoader.java
@@ -19,10 +19,8 @@ package io.microsphere.spring.config.context.annotation;
 import io.microsphere.io.StandardFileWatchService;
 import io.microsphere.io.event.FileChangedEvent;
 import io.microsphere.io.event.FileChangedListener;
-import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -51,8 +49,7 @@ import static io.microsphere.spring.core.io.ResourceUtils.isFileBasedResource;
  * @since 1.0.0
  */
 public class ResourcePropertySourceLoader extends PropertySourceExtensionLoader<ResourcePropertySource,
-        PropertySourceExtensionAttributes<ResourcePropertySource>> implements InitializingBean, ResourceLoaderAware,
-        BeanClassLoaderAware, DisposableBean {
+        PropertySourceExtensionAttributes<ResourcePropertySource>> implements InitializingBean, DisposableBean {
 
     private ResourcePatternResolver resourcePatternResolver;
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourcesLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourcesLoader.java
@@ -16,8 +16,6 @@
  */
 package io.microsphere.spring.config.context.annotation;
 
-import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
@@ -37,8 +35,7 @@ import static io.microsphere.spring.core.annotation.GenericAnnotationAttributes.
  * @see AnnotatedPropertySourceLoader
  * @since 1.0.0
  */
-class ResourcePropertySourcesLoader extends AnnotatedPropertySourceLoader<ResourcePropertySources> implements
-        ResourceLoaderAware, BeanClassLoaderAware {
+class ResourcePropertySourcesLoader extends AnnotatedPropertySourceLoader<ResourcePropertySources> {
 
     /**
      * Loads property sources from each {@link ResourcePropertySource} annotation declared

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -22,9 +22,7 @@ import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttr
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
-import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
@@ -39,11 +37,12 @@ import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
+import static org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator.INSTANCE;
 import static org.springframework.core.ResolvableType.forType;
 
 /**
- * An abstract base class for {@link ImportSelector} and {@link ImportBeanDefinitionRegistrar} implementations
- * that are driven by a specific annotation type {@code A}.
+ * An abstract base class for {@link ImportBeanDefinitionRegistrar} implementations that are driven by a specific
+ * annotation type {@code A}.
  * <p>
  * This class extends {@link BeanCapableImportCandidate} to provide common bean import capabilities,
  * while adding support for processing annotation attributes with placeholder resolution.
@@ -52,7 +51,6 @@ import static org.springframework.core.ResolvableType.forType;
  * <h3>Key Features</h3>
  * <ul>
  *     <li>Automatically resolves the generic annotation type {@code A} at runtime.</li>
- *     <li>Integrates with Spring's {@link ImportSelector} and {@link ImportBeanDefinitionRegistrar} interfaces.</li>
  *     <li>Supports enabling/disabling imports via environment properties (see {@link #isEnabled(Environment, String, Class)}).</li>
  *     <li>Provides resolved annotation attributes via {@link ResolvablePlaceholderAnnotationAttributes}.</li>
  * </ul>
@@ -125,7 +123,6 @@ import static org.springframework.core.ResolvableType.forType;
  * @param <A> the type of the annotation that drives this import candidate
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see BeanCapableImportCandidate
- * @see ImportSelector
  * @see ImportBeanDefinitionRegistrar
  * @see ResolvablePlaceholderAnnotationAttributes
  * @since 1.0.0
@@ -133,16 +130,13 @@ import static org.springframework.core.ResolvableType.forType;
 public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate
         implements ImportBeanDefinitionRegistrar {
 
-    static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
-
     protected final Class<A> annotationType;
 
     public AnnotatedBeanCapableImportCandidate() {
         this.annotationType = resolveAnnotationType();
     }
 
-    // @Override // This method is declared in ImportBeanDefinitionRegistrar since Spring 5.2,
-    // thus the @Override was commented for compatibility with older versions.
+    @Override
     public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
                                               BeanNameGenerator importBeanNameGenerator) {
         if (isEnabled(metadata)) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -208,7 +208,8 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
      * @param annotationAttributes the resolved annotation attributes with placeholders resolved
      * @param imports              the set of class names to import; add desired classes to this set
      */
-    protected void selectImports(AnnotationMetadata metadata, ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
+    protected void selectImports(AnnotationMetadata metadata,
+                                 ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
                                  Set<String> imports) {
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -19,27 +19,145 @@ package io.microsphere.spring.context.annotation;
 
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.AnnotationBeanNameGenerator;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 
+import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
+import static io.microsphere.constants.SymbolConstants.AT_CHAR;
+import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
+import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
+import static io.microsphere.spring.constants.PropertyConstants.MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.ResolvableType.forType;
 
 /**
- * The extension of {@link BeanCapableImportCandidate} for Annotated {@link Configuration} class
+ * An abstract base class for {@link ImportSelector} and {@link ImportBeanDefinitionRegistrar} implementations
+ * that are driven by a specific annotation type {@code A}.
+ * <p>
+ * This class extends {@link BeanCapableImportCandidate} to provide common bean import capabilities,
+ * while adding support for processing annotation attributes with placeholder resolution.
+ * Subclasses must specify the annotation type {@code A} via generics.
  *
+ * <h3>Key Features</h3>
+ * <ul>
+ *     <li>Automatically resolves the generic annotation type {@code A} at runtime.</li>
+ *     <li>Integrates with Spring's {@link ImportSelector} and {@link ImportBeanDefinitionRegistrar} interfaces.</li>
+ *     <li>Supports enabling/disabling imports via environment properties (see {@link #isEnabled(Environment, String, Class)}).</li>
+ *     <li>Provides resolved annotation attributes via {@link ResolvablePlaceholderAnnotationAttributes}.</li>
+ * </ul>
+ *
+ * <h3>Usage Example: ImportSelector</h3>
+ * Suppose you want to create an import candidate for an annotation {@code @EnableMyFeature}:
+ *
+ * <pre>{@code
+ * @Target(ElementType.TYPE)
+ * @Retention(RetentionPolicy.RUNTIME)
+ * @Documented
+ * public @interface EnableMyFeature {
+ *     String value() default "";
+ * }
+ *
+ * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
+ *
+ *     @Override
+ *     protected void selectImports(AnnotationMetadata metadata,
+ *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
+ *                                  Set<String> imports) {
+ *         String featureName = attributes.getString("value");
+ *         if (StringUtils.hasText(featureName)) {
+ *             imports.add("com.example.MyFeatureConfig");
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>
+ * To use this candidate, you would typically register it via a meta-annotation or directly in a configuration:
+ *
+ * <pre>{@code
+ * @Configuration
+ * @Import(MyFeatureImportCandidate.class)
+ * @EnableMyFeature("test")
+ * public class AppConfig {
+ *     // ...
+ * }
+ * }</pre>
+ *
+ * <h3>Usage Example: ImportBeanDefinitionRegistrar</h3>
+ * You can also use this class to register bean definitions programmatically:
+ *
+ * <pre>{@code
+ * public class MyFeatureRegistrar extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
+ *
+ *     @Override
+ *     protected void registerBeanDefinitions(AnnotationMetadata metadata,
+ *                                            BeanDefinitionRegistry registry,
+ *                                            ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes) {
+ *         String featureName = attributes.getString("value");
+ *         if (StringUtils.hasText(featureName)) {
+ *             GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+ *             beanDefinition.setBeanClass(MyFeatureService.class);
+ *             beanDefinition.getPropertyValues().add("name", featureName);
+ *             registry.registerBeanDefinition("myFeatureService", beanDefinition);
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h3>Property-Based Control</h3>
+ * The import can be controlled via properties:
+ * <ul>
+ *     <li>Class-specific: {@code microsphere.spring.com.example.AppConfig@com.example.EnableMyFeature.enabled=false}</li>
+ *     <li>Global: {@code microsphere.spring.com.example.EnableMyFeature.enabled=false}</li>
+ * </ul>
+ *
+ * @param <A> the type of the annotation that drives this import candidate
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see BeanCapableImportCandidate
+ * @see ImportSelector
+ * @see ImportBeanDefinitionRegistrar
+ * @see ResolvablePlaceholderAnnotationAttributes
  * @since 1.0.0
  */
-public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate {
+public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate
+        implements ImportBeanDefinitionRegistrar {
+
+    static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
 
     protected final Class<A> annotationType;
 
     public AnnotatedBeanCapableImportCandidate() {
         this.annotationType = resolveAnnotationType();
+    }
+
+    // @Override // This method is declared in ImportBeanDefinitionRegistrar since Spring 5.2,
+    // thus the @Override was commented for compatibility with older versions.
+    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                              BeanNameGenerator importBeanNameGenerator) {
+        if (isEnabled(metadata)) {
+            Set<String> imports = newLinkedHashSet();
+            ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes = getAnnotationAttributes(metadata);
+            selectImports(metadata, annotationAttributes, imports);
+            registerImportClassNames(imports, registry, importBeanNameGenerator);
+            registerBeanDefinitions(metadata, registry, importBeanNameGenerator, annotationAttributes);
+        }
+    }
+
+    @Override
+    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+        // This method should not be invoked since Spring 5.2, but it prevents the subclasses to implement.
+        registerBeanDefinitions(metadata, registry, INSTANCE);
     }
 
     protected Class<A> resolveAnnotationType() {
@@ -52,11 +170,104 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
         return (Class<T>) superType.resolveGeneric(index);
     }
 
+    protected boolean isEnabled(AnnotationMetadata metadata) {
+        return isEnabled(getEnvironment(), metadata.getClassName(), getAnnotationType());
+    }
+
     /**
-     * Get the {@link ResolvablePlaceholderAnnotationAttributes}
+     * Selects the class names to be imported based on the annotation attributes.
+     * <p>
+     * Subclasses should override this method to add specific class names to the {@code imports} set
+     * based on the resolved annotation attributes. The default implementation does nothing.
      *
-     * @param metadata {@link AnnotationMetadata}
-     * @return non-null
+     * <h3>Example Usage</h3>
+     * Suppose you have an annotation {@code @EnableMyFeature(value = "com.example")}:
+     * <pre>{@code
+     * @Target(ElementType.TYPE)
+     * @Retention(RetentionPolicy.RUNTIME)
+     * @Documented
+     * public @interface EnableMyFeature {
+     *     String value() default "";
+     * }
+     *
+     * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
+     *
+     *     @Override
+     *     protected void selectImports(AnnotationMetadata metadata,
+     *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
+     *                                  Set<String> imports) {
+     *         String featureName = attributes.getString("value");
+     *         if (StringUtils.hasText(featureName)) {
+     *             imports.add("com.example.MyFeatureConfig");
+     *         }
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param metadata             the {@link AnnotationMetadata} of the importing class
+     * @param annotationAttributes the resolved annotation attributes with placeholders resolved
+     * @param imports              the set of class names to import; add desired classes to this set
+     */
+    protected void selectImports(AnnotationMetadata metadata, ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
+                                 Set<String> imports) {
+    }
+
+    /**
+     * Registers bean definitions based on the annotation attributes.
+     * <p>
+     * Subclasses should override this method to register specific bean definitions
+     * into the {@link BeanDefinitionRegistry} based on the resolved annotation attributes.
+     * The default implementation does nothing.
+     *
+     * <h3>Example Usage</h3>
+     * Suppose you have an annotation {@code @EnableService(prefix = "${service.prefix}")}:
+     * <pre>{@code
+     * @Override
+     * protected void registerBeanDefinitions(AnnotationMetadata metadata,
+     *                                        BeanDefinitionRegistry registry,
+     *                                        BeanNameGenerator importBeanNameGenerator,
+     *                                        ResolvablePlaceholderAnnotationAttributes<EnableService> attributes) {
+     *     String prefix = attributes.getString("prefix");
+     *     if (StringUtils.hasText(prefix)) {
+     *         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+     *         beanDefinition.setBeanClass(MyService.class);
+     *         beanDefinition.getPropertyValues().add("prefix", prefix);
+     *         registry.registerBeanDefinition("myService", beanDefinition);
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param metadata                the {@link AnnotationMetadata} of the importing class
+     * @param registry                the {@link BeanDefinitionRegistry} to register bean definitions into
+     * @param importBeanNameGenerator the {@link BeanNameGenerator} to use for generating bean names
+     * @param annotationAttributes    the resolved annotation attributes with placeholders resolved
+     */
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes) {
+    }
+
+    /**
+     * Gets the annotation attributes from the given {@link AnnotationMetadata}, resolving any placeholders.
+     * <p>
+     * This method retrieves the attributes of the annotation type associated with this import candidate
+     * from the importing class's metadata. It uses {@link ResolvablePlaceholderAnnotationAttributes} to
+     * ensure that any property placeholders (e.g., {@code ${my.property}}) within the annotation attributes
+     * are resolved against the Spring {@link Environment}.
+     *
+     * <h3>Example Usage</h3>
+     * Suppose you have an annotation {@code @EnableFeature(name = "${feature.name}")} and a configuration class:
+     * <pre>{@code
+     * @Configuration
+     * @EnableFeature(name = "${feature.name}")
+     * public class MyConfig { ... }
+     * }</pre>
+     * If the environment property {@code feature.name} is set to {@code "MyFeature"}, calling this method
+     * will return a {@link ResolvablePlaceholderAnnotationAttributes} instance where the attribute {@code name}
+     * has the resolved value {@code "MyFeature"}.
+     *
+     * @param metadata the {@link AnnotationMetadata} of the importing class
+     * @return the resolved annotation attributes, never {@code null}
      */
     @Nonnull
     protected ResolvablePlaceholderAnnotationAttributes<A> getAnnotationAttributes(AnnotationMetadata metadata) {
@@ -71,5 +282,84 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
     @Nonnull
     public Class<A> getAnnotationType() {
         return annotationType;
+    }
+
+    void registerImportClassNames(Set<String> imports, BeanDefinitionRegistry registry, BeanNameGenerator importBeanNameGenerator) {
+        logger.trace("Importing BeanDefinitions from {}", imports);
+        for (String importClassName : imports) {
+            AbstractBeanDefinition beanDefinition = genericBeanDefinition(importClassName).getBeanDefinition();
+            String beanName = importBeanNameGenerator.generateBeanName(beanDefinition, registry);
+            registerBeanDefinition(registry, beanName, beanDefinition);
+        }
+    }
+
+    /**
+     * Checks if the import candidate is enabled based on the environment properties.
+     * <p>
+     * The check is performed in the following order:
+     * <ol>
+     *     <li>Check for a class-specific property: {@code microsphere.spring.<importing-class-name>@<annotation-class-name>.enabled}</li>
+     *     <li>If not found, check for a global property: {@code microsphere.spring.<annotation-class-name>.enabled}</li>
+     *     <li>If neither is found, default to {@code true}</li>
+     * </ol>
+     *
+     * <h3>Example Usage</h3>
+     * Given an importing class {@code com.example.MyConfiguration} and an annotation type
+     * {@code io.microsphere.spring.annotation.EnableMicrosphere}:
+     * <ul>
+     *     <li>If property {@code microsphere.spring.com.example.MyConfiguration@io.microsphere.spring.annotation.EnableMicrosphere.enabled=false} is set, returns {@code false}.</li>
+     *     <li>If the above is not set, but {@code microsphere.spring.io.microsphere.spring.annotation.EnableMicrosphere.enabled=false} is set, returns {@code false}.</li>
+     *     <li>If neither is set, returns {@code true} (default).</li>
+     * </ul>
+     *
+     * @param environment        the Spring {@link Environment} to resolve properties from
+     * @param importingClassName the name of the class importing the beans
+     * @param annotationType     the annotation type associated with the import candidate
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    static boolean isEnabled(Environment environment, String importingClassName, Class<? extends Annotation> annotationType) {
+        String propertyName = getEnabledPropertyName(importingClassName, annotationType);
+        String propertyValue = environment.getProperty(propertyName);
+        if (propertyValue == null) {
+            propertyName = getGlobalEnabledPropertyName(annotationType);
+        }
+        return environment.getProperty(propertyName, boolean.class, true);
+    }
+
+    /**
+     * Gets the property name that controls whether the import candidate is enabled for a specific importing class.
+     * <p>
+     * The property name is constructed as:
+     * {@code microsphere.spring.<importing-class-name>@<annotation-class-name>.enabled}
+     * <h3>Example Usage</h3>
+     * If the importing class is {@code com.example.MyConfiguration} and the annotation type is
+     * {@code io.microsphere.spring.annotation.EnableMicrosphere},
+     * the returned property name will be:
+     * {@code microsphere.spring.com.example.MyConfiguration@io.microsphere.spring.annotation.EnableMicrosphere.enabled}
+     *
+     * @param importingClassName the name of the importing class
+     * @param annotationType     the annotation type
+     * @return the enabled property name
+     */
+    public static String getEnabledPropertyName(String importingClassName, Class<? extends Annotation> annotationType) {
+        return MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX + importingClassName + AT_CHAR +
+                annotationType.getName() + DOT_CHAR + ENABLED_PROPERTY_NAME;
+    }
+
+    /**
+     * Gets the global property name that controls whether the import candidate is enabled for the specified annotation type.
+     * <p>
+     * The property name is constructed as:
+     * {@code microsphere.spring.<annotation-class-name>.enabled}
+     * <h3>Example Usage</h3>
+     * If the annotation type is {@code io.microsphere.spring.annotation.EnableMicrosphere},
+     * the returned property name will be:
+     * {@code microsphere.spring.io.microsphere.spring.annotation.EnableMicrosphere.enabled}
+     *
+     * @param annotationType the annotation type
+     * @return the global enabled property name
+     */
+    public static String getGlobalEnabledPropertyName(Class<? extends Annotation> annotationType) {
+        return MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX + annotationType.getName() + DOT_CHAR + ENABLED_PROPERTY_NAME;
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -22,6 +22,7 @@ import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttr
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
@@ -37,7 +38,6 @@ import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
-import static org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator.INSTANCE;
 import static org.springframework.core.ResolvableType.forType;
 
 /**
@@ -129,6 +129,8 @@ import static org.springframework.core.ResolvableType.forType;
  */
 public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate
         implements ImportBeanDefinitionRegistrar {
+
+    static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
 
     protected final Class<A> annotationType;
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -138,7 +138,8 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
         this.annotationType = resolveAnnotationType();
     }
 
-    @Override
+    // @Override // This method is declared in ImportBeanDefinitionRegistrar since Spring 5.2,
+    // thus the @Override was commented for compatibility with older versions.
     public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
                                               BeanNameGenerator importBeanNameGenerator) {
         if (isEnabled(metadata)) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -22,7 +22,6 @@ import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttr
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.core.type.AnnotationMetadata;
@@ -45,8 +44,7 @@ import static org.springframework.core.io.support.SpringFactoriesLoader.loadFact
  * @see SpringFactoriesLoader
  * @since 1.0.0
  */
-class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<EnableAutoRegistrationBean>
-        implements ImportBeanDefinitionRegistrar {
+class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<EnableAutoRegistrationBean> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -27,11 +27,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
+import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
-import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
@@ -94,7 +94,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -29,11 +29,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
+import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
-import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
@@ -96,7 +96,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -18,8 +18,10 @@
 package io.microsphere.spring.context.annotation;
 
 import io.microsphere.spring.context.config.AutoRegistrationBean;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.io.support.SpringFactoriesLoader;
@@ -27,11 +29,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
-import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
@@ -47,17 +49,22 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
         implements ImportBeanDefinitionRegistrar {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator, ResolvablePlaceholderAnnotationAttributes<EnableAutoRegistrationBean> annotationAttributes) {
+        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class, super.classLoader);
+        registerAutoRegisteredBeans(autoRegistrationBeans, registry);
+    }
+
+    @Override
+    protected boolean isEnabled(AnnotationMetadata metadata) {
         if (!isEnabled()) {
             if (logger.isTraceEnabled()) {
                 logger.trace("The @EnableAutoRegistrationBean was disabled by property[{} = false]",
                         BEANS_AUTO_REGISTERED_PROEPRTY_NAME);
             }
-            return;
+            return false;
         }
-
-        List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class, super.classLoader);
-        registerAutoRegisteredBeans(autoRegistrationBeans, registry);
+        return super.isEnabled(metadata);
     }
 
     private boolean isEnabled() {
@@ -89,7 +96,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -22,21 +22,20 @@ import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttr
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
-import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
-import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
- * {@link ImportSelector} class for {@link EnableAutoRegistrationBean}
+ * {@link AnnotatedBeanCapableImportCandidate} class for {@link EnableAutoRegistrationBean}
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see EnableAutoRegistrationBean
@@ -48,7 +47,8 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
-                                           BeanNameGenerator importBeanNameGenerator, ResolvablePlaceholderAnnotationAttributes<EnableAutoRegistrationBean> annotationAttributes) {
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableAutoRegistrationBean> annotationAttributes) {
         List<AutoRegistrationBean> autoRegistrationBeans = loadFactories(AutoRegistrationBean.class, super.classLoader);
         registerAutoRegisteredBeans(autoRegistrationBeans, registry);
     }
@@ -94,7 +94,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/BeanCapableImportCandidate.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -47,6 +46,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
+import static io.microsphere.constants.SymbolConstants.AT_CHAR;
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.initializeBean;
 import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asBeanDefinitionRegistry;
@@ -61,17 +61,19 @@ import static java.lang.Integer.toHexString;
 import static org.springframework.beans.BeanUtils.instantiateClass;
 
 /**
- * The {@link Import @Import} candidate is an instance of {@link org.springframework.context.annotation.ImportSelector} or {@link ImportBeanDefinitionRegistrar}
- * and not a regular Spring bean, which only invokes {@link BeanClassLoaderAware}, {@link BeanFactoryAware},
- * {@link EnvironmentAware}, and {@link ResourceLoaderAware} contracts in order if they are implemented, thus it will
- * not be {@link AbstractAutowireCapableBeanFactory#populateBean(String, RootBeanDefinition, BeanWrapper) populated} and
- * {@link AutowireCapableBeanFactory#initializeBean(Object, String) initialized} .
+ * An abstract base class for {@link Import @Import} candidates that supports the full Spring bean lifecycle,
+ * including population, initialization, and destruction.
  * <p>
- * The current abstract implementation is a template class supports the Spring bean lifecycles :
- * {@link AbstractAutowireCapableBeanFactory#populateBean(String, RootBeanDefinition, BeanWrapper) population},
- * {@link AutowireCapableBeanFactory#initializeBean(Object, String) initialization}, and
- * {@link ConfigurableBeanFactory#destroyBean(String, Object) destroy}, the sub-class must implement
- * the interface {@link ImportSelector} or {@link ImportBeanDefinitionRegistrar}, and can't override those methods:
+ * Unlike standard {@link ImportSelector} or {@link ImportBeanDefinitionRegistrar} implementations, which are
+ * typically instantiated and invoked without full bean lifecycle management, this class ensures that the
+ * candidate instance is treated as a Spring-managed bean. It achieves this by implementing key awareness
+ * interfaces ({@link BeanClassLoaderAware}, {@link BeanFactoryAware}, {@link EnvironmentAware},
+ * {@link ApplicationContextAware}, and {@link ResourceLoaderAware}) and triggering self-registration
+ * and initialization upon setting the {@link ResourceLoader}.
+ * <p>
+ * Subclasses must implement either {@link ImportSelector} or {@link ImportBeanDefinitionRegistrar} to define
+ * their import logic. They can then leverage injected dependencies and lifecycle callbacks provided by the
+ * Spring container, and can't override those methods:
  * <ul>
  *     <li>{@link #setBeanClassLoader(ClassLoader)}</li>
  *     <li>{@link #setBeanFactory(BeanFactory)}</li>
@@ -80,24 +82,59 @@ import static org.springframework.beans.BeanUtils.instantiateClass;
  *     <li>{@link #setApplicationContext(ApplicationContext)}</li>
  * </ul>
  *
+ * <h3>Key Features</h3>
+ * <ul>
+ *     <li>Supports dependency injection via {@link AbstractAutowireCapableBeanFactory#populateBean(String, RootBeanDefinition, BeanWrapper)}.</li>
+ *     <li>Supports initialization callbacks via {@link AutowireCapableBeanFactory#initializeBean}.</li>
+ *     <li>Provides access to {@link ConfigurableListableBeanFactory}, {@link ConfigurableEnvironment},
+ *         {@link ConfigurableApplicationContext}, and {@link ResourceLoader}.</li>
+ *     <li>Ensures the candidate is registered as a singleton bean in the context.</li>
+ * </ul>
+ *
  * <h3>Example Usage</h3>
  *
  * <pre>{@code
- * public class MyImportRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
+ * // 1. Define a custom ImportSelector extending BeanCapableImportCandidate
+ * public class MyImportSelector extends BeanCapableImportCandidate implements ImportSelector {
  *
- *     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
- *         logger.info("Registering beans from custom registrar");
- *         registry.registerBeanDefinition("myBean", new RootBeanDefinition(MyBean.class));
+ *     // You can inject dependencies here if needed, though typically done via getter methods
+ *     // provided by the base class after initialization.
+ *
+ *     @Override
+ *     public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+ *         // Access the environment to resolve placeholders or make decisions
+ *         String profile = getEnvironment().getActiveProfiles().length > 0 ?
+ *             getEnvironment().getActiveProfiles()[0] : "default";
+ *
+ *         logger.info("Selecting imports for profile: {}", profile);
+ *
+ *         // Return classes to import based on logic
+ *         if ("prod".equals(profile)) {
+ *             return new String[]{ProdConfig.class.getName()};
+ *         } else {
+ *             return new String[]{DevConfig.class.getName()};
+ *         }
  *     }
+ * }
+ *
+ * // 2. Use the selector in a configuration class
+ * @Import(MyImportSelector.class)
+ * @Configuration
+ * public class AppConfig {
+ *     // ...
  * }
  * }</pre>
  *
- * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
- * @see OverrideAnnotationAttributes
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ImportSelector
+ * @see ImportBeanDefinitionRegistrar
+ * @see BeanClassLoaderAware
+ * @see BeanFactoryAware
+ * @see EnvironmentAware
+ * @see ApplicationContextAware
+ * @see ResourceLoaderAware
  * @see AbstractAutowireCapableBeanFactory#populateBean(String, RootBeanDefinition, BeanWrapper)
- * @see AutowireCapableBeanFactory#initializeBean(Object, String)
- * @see ConfigurableBeanFactory#destroyBean(String, Object)
- * @see org.springframework.context.support.ApplicationContextAwareProcessor
+ * @see AutowireCapableBeanFactory#initializeBean
  * @since 1.0.0
  */
 public abstract class BeanCapableImportCandidate implements BeanClassLoaderAware, BeanFactoryAware, EnvironmentAware,
@@ -265,12 +302,40 @@ public abstract class BeanCapableImportCandidate implements BeanClassLoaderAware
     }
 
     /**
-     * Get the {@link ResolvablePlaceholderAnnotationAttributes} of the specified {@link Annotation}
+     * Retrieves the {@link ResolvablePlaceholderAnnotationAttributes} for the specified annotation type from the given metadata.
+     * <p>
+     * This method resolves placeholders in the annotation attributes using the current {@link Environment}.
+     * It also checks for any {@link OverrideAnnotationAttributes} meta-annotation on the target annotation type
+     * and applies the configured {@link OverrideAnnotationAttributesStrategy} if present.
      *
-     * @param metadata       {@link AnnotationMetadata}
-     * @param annotationType the annotation type
-     * @param <A>            the annotation type
-     * @return non-null
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // Assume @MyConfig is a custom annotation with placeholder support
+     * @MyConfig(value = "${my.config.value}")
+     * @Import(MyImportSelector.class)
+     * public class AppConfig { }
+     *
+     * public class MyImportSelector extends BeanCapableImportCandidate implements ImportSelector {
+     *
+     *     @Override
+     *     public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+     *         // Retrieve resolved annotation attributes
+     *         ResolvablePlaceholderAnnotationAttributes<MyConfig> attributes =
+     *             getAnnotationAttributes(importingClassMetadata, MyConfig.class);
+     *
+     *         // Access the resolved value (placeholders replaced by environment properties)
+     *         String value = attributes.getString("value");
+     *         logger.info("Resolved config value: {}", value);
+     *
+     *         return new String[0];
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param metadata       the {@link AnnotationMetadata} of the importing class
+     * @param annotationType the {@link Class} of the annotation to retrieve attributes for
+     * @param <A>            the type of the annotation
+     * @return the {@link ResolvablePlaceholderAnnotationAttributes} containing the resolved annotation attributes
      */
     @Nonnull
     protected <A extends Annotation> ResolvablePlaceholderAnnotationAttributes<A> getAnnotationAttributes(AnnotationMetadata metadata, Class<A> annotationType) {
@@ -334,7 +399,7 @@ public abstract class BeanCapableImportCandidate implements BeanClassLoaderAware
     }
 
     private void initializeSelfAsBean() {
-        String beanName = getClass().getName() + "@" + toHexString(hashCode());
+        String beanName = getClass().getName() + AT_CHAR + toHexString(hashCode());
         BeanDefinitionRegistry registry = asBeanDefinitionRegistry(this.beanFactory);
         // register the current instance as a Spring BeanDefinition
         registerBean(registry, beanName, this);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptionalSelector.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptionalSelector.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static io.microsphere.util.ClassLoaderUtils.resolveClass;
@@ -35,16 +36,17 @@ import static io.microsphere.util.ClassLoaderUtils.resolveClass;
  * @see ImportSelector
  * @since 1.0.0
  */
-class ImportOptionalSelector extends AnnotatedBeanCapableImportCandidate<ImportOptional> implements ImportSelector {
+class ImportOptionalSelector extends AnnotatedBeanCapableImportCandidate<ImportOptional> {
 
     @Override
-    public String[] selectImports(AnnotationMetadata metadata) {
-        ResolvablePlaceholderAnnotationAttributes attributes = getAnnotationAttributes(metadata);
-        String[] classNames = attributes.getStringArray("value");
-        return Stream.of(classNames)
+    protected void selectImports(AnnotationMetadata metadata, ResolvablePlaceholderAnnotationAttributes<ImportOptional> annotationAttributes,
+                                 Set<String> imports) {
+        String[] classNames = annotationAttributes.getStringArray("value");
+        Stream.of(classNames)
                 .map(className -> resolveClass(className, getClassLoader()))
                 .filter(Objects::nonNull)
                 .map(Class::getName)
-                .toArray(String[]::new);
+                .forEach(imports::add);
+
     }
 }

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
@@ -24,8 +24,8 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.type.AnnotationMetadata;
@@ -52,7 +52,7 @@ import static org.springframework.context.support.AbstractApplicationContext.APP
  * @see TaskExecutor
  * @since 1.0.0
  */
-class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableEventExtension> implements ImportBeanDefinitionRegistrar {
+class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableEventExtension> {
 
     /**
      * The attribute name of the name of {@link EnableEventExtension} annotated on the class
@@ -60,12 +60,13 @@ class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<Enable
     static final String CLASS_NAME_ATTRIBUTE_NAME = "@className";
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        registerApplicationEventMulticaster(metadata, registry);
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator, ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes) {
+        registerApplicationEventMulticaster(metadata, registry, annotationAttributes);
     }
 
-    void registerApplicationEventMulticaster(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes = getAnnotationAttributes(metadata);
+    void registerApplicationEventMulticaster(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                             ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes) {
 
         EventExtensionAttributes attributes = new EventExtensionAttributes(annotationAttributes);
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
@@ -61,7 +61,8 @@ class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<Enable
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
-                                           BeanNameGenerator importBeanNameGenerator, ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes) {
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableEventExtension> annotationAttributes) {
         registerApplicationEventMulticaster(metadata, registry, annotationAttributes);
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/convert/annotation/EnableSpringConverterAdapterRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/convert/annotation/EnableSpringConverterAdapterRegistrar.java
@@ -16,21 +16,19 @@
  */
 package io.microsphere.spring.core.convert.annotation;
 
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.core.convert.SpringConverterAdapter;
 import io.microsphere.spring.core.convert.support.ConversionServiceResolver;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.ConverterRegistry;
 import org.springframework.core.type.AnnotationMetadata;
 
-import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableBeanFactory;
+import java.util.Set;
+
 import static io.microsphere.spring.core.convert.SpringConverterAdapter.INSTANCE;
-import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
 
 /**
  * {@link EnableSpringConverterAdapter} {@link Configuration} class
@@ -40,17 +38,13 @@ import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
  * @see SpringConverterAdapter
  * @since 1.0.0
  */
-class EnableSpringConverterAdapterRegistrar implements ImportSelector, BeanFactoryAware {
+class EnableSpringConverterAdapterRegistrar extends AnnotatedBeanCapableImportCandidate<EnableSpringConverterAdapter> {
 
     @Override
-    public String[] selectImports(AnnotationMetadata importingClassMetadata) {
-        return EMPTY_STRING_ARRAY;
-    }
-
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        ConfigurableBeanFactory configurableBeanFactory = asConfigurableBeanFactory(beanFactory);
-        addSpringConverterAdapter(configurableBeanFactory);
+    protected void selectImports(AnnotationMetadata metadata,
+                                 ResolvablePlaceholderAnnotationAttributes<EnableSpringConverterAdapter> annotationAttributes,
+                                 Set<String> imports) {
+        addSpringConverterAdapter(getBeanFactory());
     }
 
     private void addSpringConverterAdapter(ConfigurableBeanFactory beanFactory) {

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/beans/factory/support/BeanRegistrarTest.java
@@ -148,6 +148,14 @@ public class BeanRegistrarTest {
     }
 
     @Test
+    public void testRegisterBeanDefinitionWithBeanDefinition() {
+        BeanDefinition beanDefinition = genericBeanDefinition(User.class);
+        assertTrue(registerBeanDefinition(this.beanFactory, beanDefinition));
+
+        assertTrue(registerBeanDefinition(this.beanFactory, beanDefinition));
+    }
+
+    @Test
     public void testRegisterSingleton() {
         registerUserAsSingleton();
     }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
@@ -24,7 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.CompositePropertySource;
@@ -136,7 +136,7 @@ public class ResourcePropertySourceLoaderTest {
 
     @Test
     public void testOnNotFoundConfig() {
-        assertThrows(BeanDefinitionStoreException.class,
+        assertThrows(BeanCreationException.class,
                 () -> testInSpringContainer((context, environment) -> {
                 }, NotFoundConfig.class));
     }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidateTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.type.StandardAnnotationMetadata;
+
+import static io.microsphere.spring.beans.BeanUtils.initializeBean;
+
+/**
+ * {@link AnnotatedBeanCapableImportCandidate} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AnnotatedBeanCapableImportCandidate
+ * @since 1.0.0
+ */
+@ImportOptional(value = {
+        "io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidateTest",
+})
+public class AnnotatedBeanCapableImportCandidateTest {
+
+    private DefaultListableBeanFactory beanFactory;
+
+    private ConfigurableApplicationContext context;
+
+    private StandardAnnotationMetadata metadata;
+
+    private ImportOptionalSelector selector;
+
+    @Before
+    public void setUp() {
+        this.beanFactory = new DefaultListableBeanFactory();
+        this.context = new AnnotationConfigApplicationContext(beanFactory);
+        this.context.refresh();
+        this.metadata = new StandardAnnotationMetadata(AnnotatedBeanCapableImportCandidateTest.class);
+        this.selector = new ImportOptionalSelector();
+        initializeBean(this.selector, this.context);
+    }
+
+    @Test
+    public void testRegisterBeanDefinitions() {
+        this.selector.registerBeanDefinitions(this.metadata, this.beanFactory);
+    }
+}

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/core/annotation/GenericAnnotationAttributesTest.java
@@ -24,7 +24,6 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import static io.microsphere.collection.MapUtils.newHashMap;

--- a/microsphere-spring-jdbc/src/main/java/io/microsphere/spring/jdbc/p6spy/annotation/P6DataSourceBeanDefinitionRegistrar.java
+++ b/microsphere-spring-jdbc/src/main/java/io/microsphere/spring/jdbc/p6spy/annotation/P6DataSourceBeanDefinitionRegistrar.java
@@ -19,39 +19,38 @@ package io.microsphere.spring.jdbc.p6spy.annotation;
 import com.p6spy.engine.spy.P6Factory;
 import com.p6spy.engine.spy.P6ModuleManager;
 import com.p6spy.engine.spy.option.P6OptionChangedListener;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.jdbc.p6spy.beans.factory.CompoundJdbcEventListenerFactory;
 import io.microsphere.spring.jdbc.p6spy.beans.factory.config.P6DataSourceBeanPostProcessor;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
-import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asConfigurableListableBeanFactory;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 
 /**
- * The {@link ImportBeanDefinitionRegistrar} class to register {@link BeanDefinition BeanDefinitions}
+ * The {@link EnableP6DataSource @EnableP6DataSource} {@link ImportBeanDefinitionRegistrar} class to
+ * register {@link BeanDefinition BeanDefinitions}.
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see EnableP6DataSource
  * @since 1.0.0
  */
-class P6DataSourceBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar, BeanFactoryAware {
+class P6DataSourceBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableP6DataSource> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableP6DataSource> annotationAttributes) {
+        initP6ModuleManager(getBeanFactory());
         registerBeanDefinition(registry, P6DataSourceBeanPostProcessor.class);
-    }
-
-    @Override
-    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        initP6ModuleManager(asConfigurableListableBeanFactory(beanFactory));
     }
 
     private void initP6ModuleManager(ConfigurableListableBeanFactory beanFactory) {

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.9</microsphere-java.version>
-        <microsphere-logging.version>0.1.16</microsphere-logging.version>
+        <microsphere-logging.version>0.1.17</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.8</microsphere-java.version>
+        <microsphere-java.version>0.3.9</microsphere-java.version>
         <microsphere-logging.version>0.1.16</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
@@ -32,6 +32,7 @@ import io.microsphere.spring.web.method.support.HandlerMethodAdvice;
 import io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor;
 import io.microsphere.spring.web.method.support.HandlerMethodInterceptor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -49,25 +50,24 @@ import static io.microsphere.spring.web.method.support.DelegatingHandlerMethodAd
  * @see EnableWebExtension
  * @since 1.0.0
  */
-public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension>
-        implements ImportBeanDefinitionRegistrar {
+public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableWebExtension> annotationAttributes) {
 
-        ResolvablePlaceholderAnnotationAttributes<EnableWebExtension> attributes = getAnnotationAttributes(metadata);
+        BeanSource[] sources = (BeanSource[]) annotationAttributes.get("sources");
 
-        BeanSource[] sources = (BeanSource[]) attributes.get("sources");
+        registerWebEndpointMappings(annotationAttributes, registry, sources);
 
-        registerWebEndpointMappings(attributes, registry, sources);
+        registerInterceptHandlers(annotationAttributes, registry, sources);
 
-        registerInterceptHandlers(attributes, registry, sources);
-
-        registerEventPublishingProcessor(attributes, registry);
+        registerEventPublishingProcessor(annotationAttributes, registry);
     }
 
-    private void registerWebEndpointMappings(AnnotationAttributes attributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
-        boolean registerWebEndpointMappings = attributes.getBoolean("registerWebEndpointMappings");
+    private void registerWebEndpointMappings(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
+        boolean registerWebEndpointMappings = annotationAttributes.getBoolean("registerWebEndpointMappings");
         if (registerWebEndpointMappings) {
             registerWebEndpointMappingResolvers(registry, sources);
             registerWebEndpointMappingRegistries(registry, sources);
@@ -103,8 +103,8 @@ public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImp
         registerBeanDefinition(registry, WebEndpointMappingRegistrar.class);
     }
 
-    private void registerInterceptHandlers(AnnotationAttributes attributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
-        boolean interceptHandlerMethods = attributes.getBoolean("interceptHandlerMethods");
+    private void registerInterceptHandlers(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry, BeanSource[] sources) {
+        boolean interceptHandlerMethods = annotationAttributes.getBoolean("interceptHandlerMethods");
         if (interceptHandlerMethods) {
             registerHandlerMethodAdvices(registry, sources);
             registerHandlerMethodArgumentInterceptors(registry, sources);
@@ -129,8 +129,8 @@ public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImp
         registerBeans(registry, sources, HandlerMethodInterceptor.class);
     }
 
-    private void registerEventPublishingProcessor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean publishEvents = attributes.getBoolean("publishEvents");
+    private void registerEventPublishingProcessor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean publishEvents = annotationAttributes.getBoolean("publishEvents");
         if (publishEvents) {
             registerBeanDefinition(registry, WebEventPublisher.class);
         }

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
@@ -19,6 +19,7 @@ package io.microsphere.spring.webflux.annotation;
 
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.util.RequestContextStrategy;
 import io.microsphere.spring.webflux.handler.ReversedProxyHandlerMapping;
 import io.microsphere.spring.webflux.metadata.HandlerMappingWebEndpointMappingResolver;
@@ -30,6 +31,7 @@ import io.microsphere.spring.webflux.server.filter.RequestHandledEventPublishing
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -48,38 +50,38 @@ import static org.springframework.util.StringUtils.uncapitalize;
  * @see ImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebFluxExtension>
-        implements ImportBeanDefinitionRegistrar {
+class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebFluxExtension> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes attributes = getAnnotationAttributes(metadata);
+    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                        BeanNameGenerator importBeanNameGenerator,
+                                        ResolvablePlaceholderAnnotationAttributes<EnableWebFluxExtension> annotationAttributes) {
 
-        registerWebEndpointMappingResolver(attributes, registry);
+        registerWebEndpointMappingResolver(annotationAttributes, registry);
 
-        registerInterceptingHandlerMethodProcessor(attributes, registry);
+        registerInterceptingHandlerMethodProcessor(annotationAttributes, registry);
 
-        registerEventPublishingProcessor(attributes, registry);
+        registerEventPublishingProcessor(annotationAttributes, registry);
 
-        registerRequestContextWebFilter(attributes, registry);
+        registerRequestContextWebFilter(annotationAttributes, registry);
 
-        registerStoringRequestBodyArgumentInterceptor(attributes, registry);
+        registerStoringRequestBodyArgumentInterceptor(annotationAttributes, registry);
 
-        registerStoringResponseBodyReturnValueInterceptor(attributes, registry);
+        registerStoringResponseBodyReturnValueInterceptor(annotationAttributes, registry);
 
-        registerReversedProxyHandlerMapping(attributes, registry);
+        registerReversedProxyHandlerMapping(annotationAttributes, registry);
     }
 
-    private void registerWebEndpointMappingResolver(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean registerWebEndpointMappings = attributes.getBoolean("registerWebEndpointMappings");
+    private void registerWebEndpointMappingResolver(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean registerWebEndpointMappings = annotationAttributes.getBoolean("registerWebEndpointMappings");
         if (registerWebEndpointMappings) {
             registerBeanDefinition(registry, HandlerMappingWebEndpointMappingResolver.class);
         }
         log("@EnableWebFluxExtension.registerWebEndpointMappings = {}", registerWebEndpointMappings);
     }
 
-    private void registerInterceptingHandlerMethodProcessor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean interceptHandlerMethods = attributes.getBoolean("interceptHandlerMethods");
+    private void registerInterceptingHandlerMethodProcessor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean interceptHandlerMethods = annotationAttributes.getBoolean("interceptHandlerMethods");
         if (interceptHandlerMethods) {
             String beanName = InterceptingHandlerMethodProcessor.BEAN_NAME;
             registerBeanDefinition(registry, beanName, InterceptingHandlerMethodProcessor.class);
@@ -87,16 +89,16 @@ class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImport
         log("@EnableWebFluxExtension.interceptHandlerMethods() = {}", interceptHandlerMethods);
     }
 
-    private void registerEventPublishingProcessor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean publishEvents = attributes.getBoolean("publishEvents");
+    private void registerEventPublishingProcessor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean publishEvents = annotationAttributes.getBoolean("publishEvents");
         if (publishEvents) {
             registerBeanDefinition(registry, RequestHandledEventPublishingWebFilter.class);
         }
         log("@EnableWebFluxExtension.publishEvents() = {}", publishEvents);
     }
 
-    private void registerRequestContextWebFilter(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        RequestContextStrategy requestContextStrategy = attributes.getEnum("requestContextStrategy");
+    private void registerRequestContextWebFilter(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        RequestContextStrategy requestContextStrategy = annotationAttributes.getEnum("requestContextStrategy");
         Boolean threadContextInheritable;
         switch (requestContextStrategy) {
             case THREAD_LOCAL:
@@ -120,24 +122,24 @@ class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImport
         log("@EnableWebFluxExtension.requestContextStrategy() = {}", requestContextStrategy);
     }
 
-    private void registerStoringRequestBodyArgumentInterceptor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean storeRequestBodyArgument = attributes.getBoolean("storeRequestBodyArgument");
+    private void registerStoringRequestBodyArgumentInterceptor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean storeRequestBodyArgument = annotationAttributes.getBoolean("storeRequestBodyArgument");
         if (storeRequestBodyArgument) {
             registerBeanDefinition(registry, StoringRequestBodyArgumentInterceptor.class);
         }
         log("@EnableWebFluxExtension.storeRequestBodyArgument() = {}", storeRequestBodyArgument);
     }
 
-    private void registerStoringResponseBodyReturnValueInterceptor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean storeResponseBodyReturnValue = attributes.getBoolean("storeResponseBodyReturnValue");
+    private void registerStoringResponseBodyReturnValueInterceptor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean storeResponseBodyReturnValue = annotationAttributes.getBoolean("storeResponseBodyReturnValue");
         if (storeResponseBodyReturnValue) {
             registerBeanDefinition(registry, StoringResponseBodyReturnValueInterceptor.class);
         }
         log("@EnableWebFluxExtension.storeResponseBodyReturnValue() = {}", storeResponseBodyReturnValue);
     }
 
-    private void registerReversedProxyHandlerMapping(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean reversedProxyHandlerMapping = attributes.getBoolean("reversedProxyHandlerMapping");
+    private void registerReversedProxyHandlerMapping(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean reversedProxyHandlerMapping = annotationAttributes.getBoolean("reversedProxyHandlerMapping");
         if (reversedProxyHandlerMapping) {
             registerBeanDefinition(registry, ReversedProxyHandlerMapping.class);
         }

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/EnableWebMvcExtension.java
@@ -81,8 +81,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @EnableWebExtension
 @OverrideAnnotationAttributes
 @Import(value = {
-        WebMvcExtensionBeanDefinitionRegistrar.class,
-        WebMvcExtensionConfiguration.class
+        WebMvcExtensionBeanDefinitionRegistrar.class
 })
 public @interface EnableWebMvcExtension {
 

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -59,8 +59,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * @see ReversedProxyHandlerMapping
  * @since 1.0.0
  */
-class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension>
-        implements ImportBeanDefinitionRegistrar {
+class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension> {
 
     private static final Class<? extends HandlerInterceptor>[] ALL_HANDLER_INTERCEPTOR_CLASSES = ofArray(HandlerInterceptor.class);
 

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -67,29 +67,29 @@ class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportC
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
                                         BeanNameGenerator importBeanNameGenerator,
-                                        ResolvablePlaceholderAnnotationAttributes<EnableWebMvcExtension> attributes) {
+                                        ResolvablePlaceholderAnnotationAttributes<EnableWebMvcExtension> annotationAttributes) {
 
         registerWebMvcExtensionConfiguration(registry);
 
-        registerWebEndpointMappingResolvers(attributes, registry);
+        registerWebEndpointMappingResolvers(annotationAttributes, registry);
 
-        registerInterceptingHandlerMethodProcessor(attributes, registry);
+        registerInterceptingHandlerMethodProcessor(annotationAttributes, registry);
 
-        registerHandlerInterceptors(attributes, registry);
+        registerHandlerInterceptors(annotationAttributes, registry);
 
-        registerStoringRequestBodyArgumentAdvice(attributes, registry);
+        registerStoringRequestBodyArgumentAdvice(annotationAttributes, registry);
 
-        registerStoringResponseBodyReturnValueAdvice(attributes, registry);
+        registerStoringResponseBodyReturnValueAdvice(annotationAttributes, registry);
 
-        registerReversedProxyHandlerMapping(attributes, registry);
+        registerReversedProxyHandlerMapping(annotationAttributes, registry);
     }
 
     private void registerWebMvcExtensionConfiguration(BeanDefinitionRegistry registry) {
         registerBeanDefinition(registry, WebMvcExtensionConfiguration.class);
     }
 
-    private void registerWebEndpointMappingResolvers(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean registerWebEndpointMappings = attributes.getBoolean("registerWebEndpointMappings");
+    private void registerWebEndpointMappingResolvers(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean registerWebEndpointMappings = annotationAttributes.getBoolean("registerWebEndpointMappings");
         if (registerWebEndpointMappings) {
             registerBeanDefinition(registry, ServletWebEndpointMappingResolver.class);
             registerBeanDefinition(registry, HandlerMappingWebEndpointMappingResolver.class);
@@ -97,8 +97,8 @@ class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportC
         log("@EnableWebMvcExtension.registerWebEndpointMappings = {}", registerWebEndpointMappings);
     }
 
-    private void registerInterceptingHandlerMethodProcessor(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean interceptHandlerMethods = attributes.getBoolean("interceptHandlerMethods");
+    private void registerInterceptingHandlerMethodProcessor(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean interceptHandlerMethods = annotationAttributes.getBoolean("interceptHandlerMethods");
         if (interceptHandlerMethods) {
             String beanName = InterceptingHandlerMethodProcessor.BEAN_NAME;
             registerBeanDefinition(registry, beanName, InterceptingHandlerMethodProcessor.class);
@@ -106,18 +106,18 @@ class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportC
         log("@EnableWebMvcExtension.interceptHandlerMethods() = {}", interceptHandlerMethods);
     }
 
-    private void registerHandlerInterceptors(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        Class<? extends HandlerInterceptor>[] interceptorClasses = resolveHandlerInterceptorClasses(attributes);
+    private void registerHandlerInterceptors(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        Class<? extends HandlerInterceptor>[] interceptorClasses = resolveHandlerInterceptorClasses(annotationAttributes);
         if (isNotEmpty(interceptorClasses)) {
             registerLazyCompositeHandlerInterceptor(registry, interceptorClasses);
             registerInterceptors(registry, interceptorClasses);
         }
     }
 
-    private Class<? extends HandlerInterceptor>[] resolveHandlerInterceptorClasses(AnnotationAttributes attributes) {
-        boolean registerHandlerInterceptors = attributes.getBoolean("registerHandlerInterceptors");
+    private Class<? extends HandlerInterceptor>[] resolveHandlerInterceptorClasses(AnnotationAttributes annotationAttributes) {
+        boolean registerHandlerInterceptors = annotationAttributes.getBoolean("registerHandlerInterceptors");
         Class<? extends HandlerInterceptor>[] handlerInterceptors =
-                (Class<? extends HandlerInterceptor>[]) attributes.getClassArray("handlerInterceptors");
+                (Class<? extends HandlerInterceptor>[]) annotationAttributes.getClassArray("handlerInterceptors");
         Class<? extends HandlerInterceptor>[] handlerInterceptorClasses = registerHandlerInterceptors ?
                 ALL_HANDLER_INTERCEPTOR_CLASSES : handlerInterceptors;
         log("@EnableWebMvcExtension.registerHandlerInterceptors() = {} , handlerInterceptors() = {} , handlerInterceptorClasses = {}",
@@ -145,24 +145,24 @@ class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportC
         registerBeanDefinition(registry, interceptorClass);
     }
 
-    private void registerStoringRequestBodyArgumentAdvice(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean storeRequestBodyArgument = attributes.getBoolean("storeRequestBodyArgument");
+    private void registerStoringRequestBodyArgumentAdvice(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean storeRequestBodyArgument = annotationAttributes.getBoolean("storeRequestBodyArgument");
         if (storeRequestBodyArgument) {
             registerBeanDefinition(registry, StoringRequestBodyArgumentAdvice.class);
         }
         log("@EnableWebMvcExtension.storeRequestBodyArgument() = {}", storeRequestBodyArgument);
     }
 
-    private void registerStoringResponseBodyReturnValueAdvice(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean storeResponseBodyReturnValue = attributes.getBoolean("storeResponseBodyReturnValue");
+    private void registerStoringResponseBodyReturnValueAdvice(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean storeResponseBodyReturnValue = annotationAttributes.getBoolean("storeResponseBodyReturnValue");
         if (storeResponseBodyReturnValue) {
             registerBeanDefinition(registry, StoringResponseBodyReturnValueAdvice.class);
         }
         log("@EnableWebMvcExtension.storeResponseBodyReturnValue() = {}", storeResponseBodyReturnValue);
     }
 
-    private void registerReversedProxyHandlerMapping(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {
-        boolean reversedProxyHandlerMapping = attributes.getBoolean("reversedProxyHandlerMapping");
+    private void registerReversedProxyHandlerMapping(AnnotationAttributes annotationAttributes, BeanDefinitionRegistry registry) {
+        boolean reversedProxyHandlerMapping = annotationAttributes.getBoolean("reversedProxyHandlerMapping");
         if (reversedProxyHandlerMapping) {
             registerBeanDefinition(registry, ReversedProxyHandlerMapping.class);
         }

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -17,6 +17,7 @@
 package io.microsphere.spring.webmvc.annotation;
 
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.annotation.WebExtensionBeanDefinitionRegistrar;
 import io.microsphere.spring.web.metadata.ServletWebEndpointMappingResolver;
@@ -28,6 +29,7 @@ import io.microsphere.spring.webmvc.metadata.HandlerMappingWebEndpointMappingRes
 import io.microsphere.spring.webmvc.method.support.InterceptingHandlerMethodProcessor;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -47,17 +49,27 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * @see EnableWebMvcExtension
  * @see EnableWebExtension
  * @see WebExtensionBeanDefinitionRegistrar
+ * @see WebMvcExtensionConfiguration
+ * @see ServletWebEndpointMappingResolver
+ * @see HandlerMappingWebEndpointMappingResolver
+ * @see InterceptingHandlerMethodProcessor
+ * @see HandlerInterceptor
+ * @see StoringRequestBodyArgumentAdvice
+ * @see StoringResponseBodyReturnValueAdvice
+ * @see ReversedProxyHandlerMapping
  * @since 1.0.0
  */
-public class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension>
+class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension>
         implements ImportBeanDefinitionRegistrar {
 
     private static final Class<? extends HandlerInterceptor>[] ALL_HANDLER_INTERCEPTOR_CLASSES = ofArray(HandlerInterceptor.class);
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                        BeanNameGenerator importBeanNameGenerator,
+                                        ResolvablePlaceholderAnnotationAttributes<EnableWebMvcExtension> attributes) {
 
-        AnnotationAttributes attributes = getAnnotationAttributes(metadata);
+        registerWebMvcExtensionConfiguration(registry);
 
         registerWebEndpointMappingResolvers(attributes, registry);
 
@@ -70,6 +82,10 @@ public class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapable
         registerStoringResponseBodyReturnValueAdvice(attributes, registry);
 
         registerReversedProxyHandlerMapping(attributes, registry);
+    }
+
+    private void registerWebMvcExtensionConfiguration(BeanDefinitionRegistry registry) {
+        registerBeanDefinition(registry, WebMvcExtensionConfiguration.class);
     }
 
     private void registerWebEndpointMappingResolvers(AnnotationAttributes attributes, BeanDefinitionRegistry registry) {

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionConfiguration.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionConfiguration.java
@@ -17,11 +17,11 @@
 package io.microsphere.spring.webmvc.annotation;
 
 import io.microsphere.logging.Logger;
+import io.microsphere.spring.webmvc.config.WebMvcConfigurerAdapter;
 import io.microsphere.spring.webmvc.interceptor.LazyCompositeHandlerInterceptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.util.ArrayUtils.length;
@@ -34,7 +34,7 @@ import static io.microsphere.util.ArrayUtils.length;
  * @see EnableWebMvcExtension
  * @since 1.0.0
  */
-public class WebMvcExtensionConfiguration extends WebMvcConfigurerAdapter {
+public class WebMvcExtensionConfiguration implements WebMvcConfigurerAdapter {
 
     private static final Logger logger = getLogger(WebMvcExtensionConfiguration.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.3</version>
+        <version>0.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request introduces significant refactoring and modernization to the property source loader infrastructure in the `microsphere-spring-context` module. The main changes focus on unifying and simplifying the extension points for annotation-driven import candidates, improving type safety and generics handling, and aligning with newer Spring conventions. Several interfaces have been updated, and redundant or legacy code has been removed for clarity and maintainability.

**Refactoring of annotation-driven import infrastructure:**

* The `AnnotatedBeanCapableImportCandidate` class is now a generic abstract base for both `ImportSelector` and `ImportBeanDefinitionRegistrar`, providing a unified extension point for annotation-driven import logic. It now directly implements `ImportBeanDefinitionRegistrar`, adds extensive documentation, and introduces a generic, property-based enable/disable mechanism. The registration and import selection logic is now handled via new protected methods with improved generics and type safety.

**API and method signature updates:**

* The `selectImports` method in `AnnotatedPropertySourceLoader` and its subclasses (`DefaultPropertiesPropertySourceLoader`, `DefaultPropertiesPropertySourcesLoader`) has been refactored to use the new generics-based signature, accepting `ResolvablePlaceholderAnnotationAttributes` and a `Set<String>` for imports, replacing the previous `selectImports` array-returning method. This enables more flexible and type-safe import handling. [[1]](diffhunk://#diff-145473f78e2df1dea08ebfaf503c6d2c735c9889c5d475f3ddfa0122c8c445d0L68-L90) [[2]](diffhunk://#diff-a86b258602c0041225f79c9acfaa67960f7b3b01f4de762c9d230afa68147561L50-R53) [[3]](diffhunk://#diff-4e9c37b66dbc623e1119f4986440fb289c5a6497c0075b7b8780e39a4a9828b2L44-R47)

**Type safety and generics improvements:**

* Improved type safety by specifying generic types in several places, such as using `EnumerablePropertySource<?>` instead of raw types, and updating method parameters and local variables accordingly.

**Cleanup and removal of unnecessary interfaces:**

* Removed unnecessary interface implementations (`ResourceLoaderAware`, `BeanClassLoaderAware`) from `ResourcePropertySourceLoader` and `ResourcePropertySourcesLoader`, streamlining these classes and reducing boilerplate. [[1]](diffhunk://#diff-44612e7deb3d8e28c1abe9f4bc6559ae9fb1a725ec4509caeb3247ff3a07b736L22-L25) [[2]](diffhunk://#diff-44612e7deb3d8e28c1abe9f4bc6559ae9fb1a725ec4509caeb3247ff3a07b736L54-R52) [[3]](diffhunk://#diff-caa1bc99ad9f3a09971dd7de827debb05ea30d60639b1ae241f21982dad68c12L19-L20) [[4]](diffhunk://#diff-caa1bc99ad9f3a09971dd7de827debb05ea30d60639b1ae241f21982dad68c12L40-R38)

**Utility and documentation enhancements:**

* Added a new overload of `registerBeanDefinition` in `BeanRegistrar` to allow bean registration with auto-generated names, including detailed Javadoc and usage examples.

These changes collectively modernize the codebase, improve extensibility, and make it easier for developers to implement custom property source loaders and import candidates in Spring-based applications.