### PR TITLE
Refactor import candidate handling and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | 0.2.26         |
-| `1.x`  | 4.3.x – 5.3.x                  | 0.1.26         |
+| `main` | 6.0.x – 7.0.x                  | 0.2.27         |
+| `1.x`  | 4.3.x – 5.3.x                  | 0.1.27         |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
@@ -17,7 +17,7 @@
 package io.microsphere.spring.beans.factory.annotation;
 
 import io.microsphere.spring.beans.factory.support.ConfigurationBeanAliasGenerator;
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -91,7 +91,7 @@ import static org.springframework.util.StringUtils.hasText;
  * @see ConfigurationBeanBindingPostProcessor
  * @since 1.0.0
  */
-class ConfigurationBeanBindingRegistrar extends AnnotatedBeanCapableImportCandidate<EnableConfigurationBeanBinding> {
+class ConfigurationBeanBindingRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableConfigurationBeanBinding> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingsRegister.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.beans.factory.annotation;
 
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
@@ -30,7 +30,7 @@ import org.springframework.core.type.AnnotationMetadata;
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @since 1.0.0
  */
-class ConfigurationBeanBindingsRegister extends AnnotatedBeanCapableImportCandidate<EnableConfigurationBeanBindings> {
+class ConfigurationBeanBindingsRegister extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableConfigurationBeanBindings> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java
@@ -18,7 +18,7 @@ package io.microsphere.spring.config.context.annotation;
 
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.annotation.Nullable;
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportSelector;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.Configuration;
@@ -64,7 +64,7 @@ import static org.springframework.util.StringUtils.hasText;
  * @see PropertySourceExtensionLoader
  * @since 1.0.0
  */
-public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extends AnnotatedBeanCapableImportCandidate<A> {
+public abstract class AnnotatedPropertySourceLoader<A extends Annotation> extends AnnotatedBeanCapableImportSelector<A> {
 
     protected static final String NAME_ATTRIBUTE_NAME = "name";
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourceLoader.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.config.context.annotation;
 
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportSelector;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.core.env.PropertySourcesUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -43,7 +43,7 @@ import static io.microsphere.util.ArrayUtils.isEmpty;
  * @see ResourcePropertySourceLoader
  * @since 1.0.0
  */
-class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySource> {
+class DefaultPropertiesPropertySourceLoader extends AnnotatedBeanCapableImportSelector<DefaultPropertiesPropertySource> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/DefaultPropertiesPropertySourcesLoader.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.config.context.annotation;
 
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportSelector;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.PropertySource;
@@ -36,7 +36,7 @@ import static io.microsphere.spring.core.annotation.GenericAnnotationAttributes.
  * @see AnnotatedPropertySourceLoader
  * @since 1.0.0
  */
-class DefaultPropertiesPropertySourcesLoader extends AnnotatedBeanCapableImportCandidate<DefaultPropertiesPropertySources> {
+class DefaultPropertiesPropertySourcesLoader extends AnnotatedBeanCapableImportSelector<DefaultPropertiesPropertySources> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
@@ -20,6 +20,7 @@ package io.microsphere.spring.context.annotation;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.AnnotationBeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 
@@ -27,7 +28,6 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import static io.microsphere.collection.SetUtils.newLinkedHashSet;
-import static org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator.INSTANCE;
 
 /**
  * An abstract base class for {@link ImportBeanDefinitionRegistrar} implementations that are driven by a specific
@@ -65,6 +65,8 @@ import static org.springframework.context.annotation.FullyQualifiedAnnotationBea
  */
 public abstract class AnnotatedBeanCapableImportBeanDefinitionRegistrar<A extends Annotation> extends
         AnnotatedBeanCapableImportCandidate<A> implements ImportBeanDefinitionRegistrar {
+
+    public static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
 
     @Override
     public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
@@ -68,7 +68,8 @@ public abstract class AnnotatedBeanCapableImportBeanDefinitionRegistrar<A extend
 
     public static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
 
-    @Override
+    // @Override // This method is declared in ImportBeanDefinitionRegistrar since Spring 5.2,
+    // thus the @Override was commented for compatibility with older versions.
     public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
                                               BeanNameGenerator importBeanNameGenerator) {
         if (isEnabled(metadata)) {

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator.INSTANCE;
+
+/**
+ * An abstract base class for {@link ImportBeanDefinitionRegistrar} implementations that are driven by a specific
+ * annotation type {@code A}.
+ * <p>
+ * This class extends {@link AnnotatedBeanCapableImportCandidate} to provide annotation-driven import capabilities
+ * and implements {@link ImportBeanDefinitionRegistrar} to handle bean definition registration.
+ *
+ * <h3>Usage Example</h3>
+ * <pre>{@code
+ * public class MyFeatureRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableMyFeature> {
+ *
+ *     @Override
+ *     protected void registerBeanDefinitions(AnnotationMetadata metadata,
+ *                                            BeanDefinitionRegistry registry,
+ *                                            BeanNameGenerator importBeanNameGenerator,
+ *                                            ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes) {
+ *         String featureName = attributes.getString("value");
+ *         if (StringUtils.hasText(featureName)) {
+ *             GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+ *             beanDefinition.setBeanClass(MyFeatureService.class);
+ *             beanDefinition.getPropertyValues().add("name", featureName);
+ *             registry.registerBeanDefinition("myFeatureService", beanDefinition);
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <A> the annotation type that drives the import candidate selection and bean definition registration
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AnnotatedBeanCapableImportCandidate
+ * @see BeanCapableImportCandidate
+ * @see ImportBeanDefinitionRegistrar
+ * @since 1.0.0
+ */
+public abstract class AnnotatedBeanCapableImportBeanDefinitionRegistrar<A extends Annotation> extends
+        AnnotatedBeanCapableImportCandidate<A> implements ImportBeanDefinitionRegistrar {
+
+    @Override
+    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                              BeanNameGenerator importBeanNameGenerator) {
+        if (isEnabled(metadata)) {
+            Set<String> imports = newLinkedHashSet();
+            ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes = getAnnotationAttributes(metadata);
+            registerBeanDefinitions(metadata, registry, importBeanNameGenerator, annotationAttributes);
+        }
+    }
+
+    @Override
+    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+        // This method should not be invoked since Spring 5.2, but it prevents the subclasses to implement.
+        registerBeanDefinitions(metadata, registry, INSTANCE);
+    }
+
+    /**
+     * Registers bean definitions based on the annotation attributes.
+     * <p>
+     * Subclasses should override this method to register specific bean definitions
+     * into the {@link BeanDefinitionRegistry} based on the resolved annotation attributes.
+     * The default implementation does nothing.
+     *
+     * <h3>Example Usage</h3>
+     * Suppose you have an annotation {@code @EnableService(prefix = "${service.prefix}")}:
+     * <pre>{@code
+     * @Override
+     * protected void registerBeanDefinitions(AnnotationMetadata metadata,
+     *                                        BeanDefinitionRegistry registry,
+     *                                        BeanNameGenerator importBeanNameGenerator,
+     *                                        ResolvablePlaceholderAnnotationAttributes<EnableService> attributes) {
+     *     String prefix = attributes.getString("prefix");
+     *     if (StringUtils.hasText(prefix)) {
+     *         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+     *         beanDefinition.setBeanClass(MyService.class);
+     *         beanDefinition.getPropertyValues().add("prefix", prefix);
+     *         registry.registerBeanDefinition("myService", beanDefinition);
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param metadata                the {@link AnnotationMetadata} of the importing class
+     * @param registry                the {@link BeanDefinitionRegistry} to register bean definitions into
+     * @param importBeanNameGenerator the {@link BeanNameGenerator} to use for generating bean names
+     * @param annotationAttributes    the resolved annotation attributes with placeholders resolved
+     */
+    protected abstract void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                                    BeanNameGenerator importBeanNameGenerator,
+                                                    ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes);
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -19,29 +19,20 @@ package io.microsphere.spring.context.annotation;
 
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
-import org.springframework.beans.factory.support.AbstractBeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanNameGenerator;
-import org.springframework.context.annotation.AnnotationBeanNameGenerator;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.lang.annotation.Annotation;
-import java.util.Set;
 
-import static io.microsphere.collection.SetUtils.newLinkedHashSet;
 import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
 import static io.microsphere.constants.SymbolConstants.AT_CHAR;
 import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
-import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.MICROSPHERE_SPRING_PROPERTY_NAME_PREFIX;
-import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.ResolvableType.forType;
 
 /**
- * An abstract base class for {@link ImportBeanDefinitionRegistrar} implementations that are driven by a specific
+ * An abstract base class for {@link BeanCapableImportCandidate} implementations that are driven by a specific
  * annotation type {@code A}.
  * <p>
  * This class extends {@link BeanCapableImportCandidate} to provide common bean import capabilities,
@@ -55,61 +46,36 @@ import static org.springframework.core.ResolvableType.forType;
  *     <li>Provides resolved annotation attributes via {@link ResolvablePlaceholderAnnotationAttributes}.</li>
  * </ul>
  *
- * <h3>Usage Example: ImportSelector</h3>
- * Suppose you want to create an import candidate for an annotation {@code @EnableMyFeature}:
- *
+ * <h3>Usage Example</h3>
  * <pre>{@code
+ * // 1. Define your custom annotation
  * @Target(ElementType.TYPE)
  * @Retention(RetentionPolicy.RUNTIME)
- * @Documented
+ * @Import(MyFeatureImportCandidate.class)
  * public @interface EnableMyFeature {
  *     String value() default "";
  * }
  *
- * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
+ * // 2. Implement the Import Candidate
+ * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> implements
+ * ImportBeanDefinitionRegistrar {
  *
  *     @Override
- *     protected void selectImports(AnnotationMetadata metadata,
- *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
- *                                  Set<String> imports) {
- *         String featureName = attributes.getString("value");
- *         if (StringUtils.hasText(featureName)) {
- *             imports.add("com.example.MyFeatureConfig");
+ *     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+ *         if (!isEnabled(importingClassMetadata)) {
+ *             return;
  *         }
+ *         ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attrs = getAnnotationAttributes(importingClassMetadata);
+ *         String featureName = attrs.getString("value");
+ *         // Register beans based on featureName...
  *     }
  * }
- * }</pre>
  *
- * <p>
- * To use this candidate, you would typically register it via a meta-annotation or directly in a configuration:
- *
- * <pre>{@code
+ * // 3. Use in Configuration
  * @Configuration
- * @Import(MyFeatureImportCandidate.class)
- * @EnableMyFeature("test")
+ * @EnableMyFeature("my-feature")
  * public class AppConfig {
- *     // ...
- * }
- * }</pre>
- *
- * <h3>Usage Example: ImportBeanDefinitionRegistrar</h3>
- * You can also use this class to register bean definitions programmatically:
- *
- * <pre>{@code
- * public class MyFeatureRegistrar extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
- *
- *     @Override
- *     protected void registerBeanDefinitions(AnnotationMetadata metadata,
- *                                            BeanDefinitionRegistry registry,
- *                                            ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes) {
- *         String featureName = attributes.getString("value");
- *         if (StringUtils.hasText(featureName)) {
- *             GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
- *             beanDefinition.setBeanClass(MyFeatureService.class);
- *             beanDefinition.getPropertyValues().add("name", featureName);
- *             registry.registerBeanDefinition("myFeatureService", beanDefinition);
- *         }
- *     }
+ *     // Beans will be imported if enabled
  * }
  * }</pre>
  *
@@ -123,38 +89,17 @@ import static org.springframework.core.ResolvableType.forType;
  * @param <A> the type of the annotation that drives this import candidate
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see BeanCapableImportCandidate
- * @see ImportBeanDefinitionRegistrar
  * @see ResolvablePlaceholderAnnotationAttributes
+ * @see AnnotatedBeanCapableImportSelector
+ * @see AnnotatedBeanCapableImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate
-        implements ImportBeanDefinitionRegistrar {
-
-    static final AnnotationBeanNameGenerator INSTANCE = new AnnotationBeanNameGenerator();
+public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> extends BeanCapableImportCandidate {
 
     protected final Class<A> annotationType;
 
     public AnnotatedBeanCapableImportCandidate() {
         this.annotationType = resolveAnnotationType();
-    }
-
-    // @Override // This method is declared in ImportBeanDefinitionRegistrar since Spring 5.2,
-    // thus the @Override was commented for compatibility with older versions.
-    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
-                                              BeanNameGenerator importBeanNameGenerator) {
-        if (isEnabled(metadata)) {
-            Set<String> imports = newLinkedHashSet();
-            ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes = getAnnotationAttributes(metadata);
-            selectImports(metadata, annotationAttributes, imports);
-            registerImportClassNames(imports, registry, importBeanNameGenerator);
-            registerBeanDefinitions(metadata, registry, importBeanNameGenerator, annotationAttributes);
-        }
-    }
-
-    @Override
-    public final void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        // This method should not be invoked since Spring 5.2, but it prevents the subclasses to implement.
-        registerBeanDefinitions(metadata, registry, INSTANCE);
     }
 
     protected Class<A> resolveAnnotationType() {
@@ -169,80 +114,6 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
 
     protected boolean isEnabled(AnnotationMetadata metadata) {
         return isEnabled(getEnvironment(), metadata.getClassName(), getAnnotationType());
-    }
-
-    /**
-     * Selects the class names to be imported based on the annotation attributes.
-     * <p>
-     * Subclasses should override this method to add specific class names to the {@code imports} set
-     * based on the resolved annotation attributes. The default implementation does nothing.
-     *
-     * <h3>Example Usage</h3>
-     * Suppose you have an annotation {@code @EnableMyFeature(value = "com.example")}:
-     * <pre>{@code
-     * @Target(ElementType.TYPE)
-     * @Retention(RetentionPolicy.RUNTIME)
-     * @Documented
-     * public @interface EnableMyFeature {
-     *     String value() default "";
-     * }
-     *
-     * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportCandidate<EnableMyFeature> {
-     *
-     *     @Override
-     *     protected void selectImports(AnnotationMetadata metadata,
-     *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
-     *                                  Set<String> imports) {
-     *         String featureName = attributes.getString("value");
-     *         if (StringUtils.hasText(featureName)) {
-     *             imports.add("com.example.MyFeatureConfig");
-     *         }
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param metadata             the {@link AnnotationMetadata} of the importing class
-     * @param annotationAttributes the resolved annotation attributes with placeholders resolved
-     * @param imports              the set of class names to import; add desired classes to this set
-     */
-    protected void selectImports(AnnotationMetadata metadata,
-                                 ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
-                                 Set<String> imports) {
-    }
-
-    /**
-     * Registers bean definitions based on the annotation attributes.
-     * <p>
-     * Subclasses should override this method to register specific bean definitions
-     * into the {@link BeanDefinitionRegistry} based on the resolved annotation attributes.
-     * The default implementation does nothing.
-     *
-     * <h3>Example Usage</h3>
-     * Suppose you have an annotation {@code @EnableService(prefix = "${service.prefix}")}:
-     * <pre>{@code
-     * @Override
-     * protected void registerBeanDefinitions(AnnotationMetadata metadata,
-     *                                        BeanDefinitionRegistry registry,
-     *                                        BeanNameGenerator importBeanNameGenerator,
-     *                                        ResolvablePlaceholderAnnotationAttributes<EnableService> attributes) {
-     *     String prefix = attributes.getString("prefix");
-     *     if (StringUtils.hasText(prefix)) {
-     *         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
-     *         beanDefinition.setBeanClass(MyService.class);
-     *         beanDefinition.getPropertyValues().add("prefix", prefix);
-     *         registry.registerBeanDefinition("myService", beanDefinition);
-     *     }
-     * }
-     * }</pre>
-     *
-     * @param metadata                the {@link AnnotationMetadata} of the importing class
-     * @param registry                the {@link BeanDefinitionRegistry} to register bean definitions into
-     * @param importBeanNameGenerator the {@link BeanNameGenerator} to use for generating bean names
-     * @param annotationAttributes    the resolved annotation attributes with placeholders resolved
-     */
-    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
-                                           BeanNameGenerator importBeanNameGenerator,
-                                           ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes) {
     }
 
     /**
@@ -280,15 +151,6 @@ public abstract class AnnotatedBeanCapableImportCandidate<A extends Annotation> 
     @Nonnull
     public Class<A> getAnnotationType() {
         return annotationType;
-    }
-
-    void registerImportClassNames(Set<String> imports, BeanDefinitionRegistry registry, BeanNameGenerator importBeanNameGenerator) {
-        logger.trace("Importing BeanDefinitions from {}", imports);
-        for (String importClassName : imports) {
-            AbstractBeanDefinition beanDefinition = genericBeanDefinition(importClassName).getBeanDefinition();
-            String beanName = importBeanNameGenerator.generateBeanName(beanDefinition, registry);
-            registerBeanDefinition(registry, beanName, beanDefinition);
-        }
     }
 
     /**

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportSelector.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportSelector.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.context.annotation;
+
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
+
+/**
+ * An abstract base class for {@link ImportSelector} implementations that select imports based on
+ * annotation attributes with resolved placeholders.
+ * <p>
+ * This class extends {@link AnnotatedBeanCapableImportCandidate} to provide common functionality
+ * for handling annotated bean capabilities and implements {@link ImportSelector} to integrate
+ * with Spring's import mechanism.
+ *
+ * <h3>Usage Example</h3>
+ * Suppose you want to create an import selector for an annotation {@code @EnableMyFeature}:
+ *
+ * <pre>{@code
+ * @Target(ElementType.TYPE)
+ * @Retention(RetentionPolicy.RUNTIME)
+ * @Documented
+ * public @interface EnableMyFeature {
+ *     String value() default "";
+ * }
+ *
+ * public class MyFeatureImportSelector extends AnnotatedBeanCapableImportSelector<EnableMyFeature> {
+ *
+ *     @Override
+ *     protected void selectImports(AnnotationMetadata metadata,
+ *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
+ *                                  Set<String> imports) {
+ *         String featureName = attributes.getString("value");
+ *         if (StringUtils.hasText(featureName)) {
+ *             imports.add("com.example.MyFeatureConfig");
+ *         }
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <A> the type of the annotation to process
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see AnnotatedBeanCapableImportCandidate
+ * @see ImportSelector
+ * @since 1.0.0
+ */
+public abstract class AnnotatedBeanCapableImportSelector<A extends Annotation> extends
+        AnnotatedBeanCapableImportCandidate<A> implements ImportSelector {
+
+    @Override
+    public final String[] selectImports(AnnotationMetadata metadata) {
+        Set<String> imports = newLinkedHashSet();
+        selectImports(metadata, getAnnotationAttributes(metadata), imports);
+        return imports.toArray(EMPTY_STRING_ARRAY);
+    }
+
+    /**
+     * Selects the class names to be imported based on the annotation attributes.
+     * <p>
+     * Subclasses should override this method to add specific class names to the {@code imports} set
+     * based on the resolved annotation attributes. The default implementation does nothing.
+     *
+     * <h3>Example Usage</h3>
+     * Suppose you have an annotation {@code @EnableMyFeature(value = "com.example")}:
+     * <pre>{@code
+     * @Target(ElementType.TYPE)
+     * @Retention(RetentionPolicy.RUNTIME)
+     * @Documented
+     * public @interface EnableMyFeature {
+     *     String value() default "";
+     * }
+     *
+     * public class MyFeatureImportCandidate extends AnnotatedBeanCapableImportSelector<EnableMyFeature> {
+     *
+     *     @Override
+     *     protected void selectImports(AnnotationMetadata metadata,
+     *                                  ResolvablePlaceholderAnnotationAttributes<EnableMyFeature> attributes,
+     *                                  Set<String> imports) {
+     *         String featureName = attributes.getString("value");
+     *         if (StringUtils.hasText(featureName)) {
+     *             imports.add("com.example.MyFeatureConfig");
+     *         }
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param metadata             the {@link AnnotationMetadata} of the importing class
+     * @param annotationAttributes the resolved annotation attributes with placeholders resolved
+     * @param imports              the set of class names to import; add desired classes to this set
+     */
+    protected abstract void selectImports(AnnotationMetadata metadata,
+                                          ResolvablePlaceholderAnnotationAttributes<A> annotationAttributes,
+                                          Set<String> imports);
+}

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -27,11 +27,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
+import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
-import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
@@ -94,7 +94,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportBeanDefini
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AutoRegistrationBeanRegistrar.java
@@ -27,11 +27,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.List;
 
-import static io.microsphere.spring.beans.factory.support.BeanDefinitionBuilderUtils.genericBeanDefinitionBuilder;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.constants.PropertyConstants.DEFAULT_AUTO_REGISTERED_VALUE;
 import static io.microsphere.spring.context.annotation.EnableAutoRegistrationBean.BEANS_AUTO_REGISTERED_PROEPRTY_NAME;
 import static io.microsphere.spring.context.config.AutoRegistrationBean.getAutoRegisteredPropertyName;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static org.springframework.core.io.support.SpringFactoriesLoader.loadFactories;
 
 /**
@@ -43,7 +43,7 @@ import static org.springframework.core.io.support.SpringFactoriesLoader.loadFact
  * @see SpringFactoriesLoader
  * @since 1.0.0
  */
-class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<EnableAutoRegistrationBean> {
+class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableAutoRegistrationBean> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
@@ -94,7 +94,7 @@ class AutoRegistrationBeanRegistrar extends AnnotatedBeanCapableImportCandidate<
 
         Class<AutoRegistrationBean> beanType = (Class<AutoRegistrationBean>) autoRegistrationBean.getBeanType();
         String scope = autoRegistrationBean.getScope();
-        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinitionBuilder(beanType, () -> autoRegistrationBean)
+        BeanDefinitionBuilder beanDefinitionBuilder = genericBeanDefinition(beanType, () -> autoRegistrationBean)
                 .setScope(scope);
 
         autoRegistrationBean.customize(beanDefinitionBuilder);

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptionalSelector.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/ImportOptionalSelector.java
@@ -36,7 +36,7 @@ import static io.microsphere.util.ClassLoaderUtils.resolveClass;
  * @see ImportSelector
  * @since 1.0.0
  */
-class ImportOptionalSelector extends AnnotatedBeanCapableImportCandidate<ImportOptional> {
+class ImportOptionalSelector extends AnnotatedBeanCapableImportSelector<ImportOptional> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata, ResolvablePlaceholderAnnotationAttributes<ImportOptional> annotationAttributes,

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventExtensionRegistrar.java
@@ -17,7 +17,7 @@
 package io.microsphere.spring.context.event;
 
 import io.microsphere.spring.beans.BeanSource;
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -52,7 +52,7 @@ import static org.springframework.context.support.AbstractApplicationContext.APP
  * @see TaskExecutor
  * @since 1.0.0
  */
-class EventExtensionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableEventExtension> {
+class EventExtensionRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableEventExtension> {
 
     /**
      * The attribute name of the name of {@link EnableEventExtension} annotated on the class

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/core/convert/annotation/EnableSpringConverterAdapterRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/core/convert/annotation/EnableSpringConverterAdapterRegistrar.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.core.convert.annotation;
 
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportSelector;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.core.convert.SpringConverterAdapter;
 import io.microsphere.spring.core.convert.support.ConversionServiceResolver;
@@ -38,7 +38,7 @@ import static io.microsphere.spring.core.convert.SpringConverterAdapter.INSTANCE
  * @see SpringConverterAdapter
  * @since 1.0.0
  */
-class EnableSpringConverterAdapterRegistrar extends AnnotatedBeanCapableImportCandidate<EnableSpringConverterAdapter> {
+class EnableSpringConverterAdapterRegistrar extends AnnotatedBeanCapableImportSelector<EnableSpringConverterAdapter> {
 
     @Override
     protected void selectImports(AnnotationMetadata metadata,

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/config/context/annotation/ResourcePropertySourceLoaderTest.java
@@ -24,7 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.CompositePropertySource;
@@ -136,7 +136,7 @@ public class ResourcePropertySourceLoaderTest {
 
     @Test
     public void testOnNotFoundConfig() {
-        assertThrows(BeanCreationException.class,
+        assertThrows(BeanDefinitionStoreException.class,
                 () -> testInSpringContainer((context, environment) -> {
                 }, NotFoundConfig.class));
     }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrarTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrarTest.java
@@ -28,16 +28,16 @@ import org.springframework.core.type.StandardAnnotationMetadata;
 import static io.microsphere.spring.beans.BeanUtils.initializeBean;
 
 /**
- * {@link AnnotatedBeanCapableImportCandidate} Test
+ * {@link AnnotatedBeanCapableImportBeanDefinitionRegistrar} Test
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @see AnnotatedBeanCapableImportCandidate
+ * @see AnnotatedBeanCapableImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
 @ImportOptional(value = {
-        "io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidateTest",
+        "io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrarTest",
 })
-public class AnnotatedBeanCapableImportCandidateTest {
+public class AnnotatedBeanCapableImportBeanDefinitionRegistrarTest {
 
     private DefaultListableBeanFactory beanFactory;
 
@@ -45,20 +45,20 @@ public class AnnotatedBeanCapableImportCandidateTest {
 
     private StandardAnnotationMetadata metadata;
 
-    private ImportOptionalSelector selector;
+    private AutoRegistrationBeanRegistrar registrar;
 
     @Before
     public void setUp() {
         this.beanFactory = new DefaultListableBeanFactory();
         this.context = new AnnotationConfigApplicationContext(beanFactory);
         this.context.refresh();
-        this.metadata = new StandardAnnotationMetadata(AnnotatedBeanCapableImportCandidateTest.class);
-        this.selector = new ImportOptionalSelector();
-        initializeBean(this.selector, this.context);
+        this.metadata = new StandardAnnotationMetadata(AnnotatedBeanCapableImportBeanDefinitionRegistrarTest.class);
+        this.registrar = new AutoRegistrationBeanRegistrar();
+        initializeBean(this.registrar, this.context);
     }
 
     @Test
     public void testRegisterBeanDefinitions() {
-        this.selector.registerBeanDefinitions(this.metadata, this.beanFactory);
+        this.registrar.registerBeanDefinitions(this.metadata, this.beanFactory);
     }
 }

--- a/microsphere-spring-jdbc/src/main/java/io/microsphere/spring/jdbc/p6spy/annotation/P6DataSourceBeanDefinitionRegistrar.java
+++ b/microsphere-spring-jdbc/src/main/java/io/microsphere/spring/jdbc/p6spy/annotation/P6DataSourceBeanDefinitionRegistrar.java
@@ -19,7 +19,7 @@ package io.microsphere.spring.jdbc.p6spy.annotation;
 import com.p6spy.engine.spy.P6Factory;
 import com.p6spy.engine.spy.P6ModuleManager;
 import com.p6spy.engine.spy.option.P6OptionChangedListener;
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.jdbc.p6spy.beans.factory.CompoundJdbcEventListenerFactory;
 import io.microsphere.spring.jdbc.p6spy.beans.factory.config.P6DataSourceBeanPostProcessor;
@@ -43,7 +43,7 @@ import static io.microsphere.spring.beans.factory.support.BeanRegistrar.register
  * @see EnableP6DataSource
  * @since 1.0.0
  */
-class P6DataSourceBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableP6DataSource> {
+class P6DataSourceBeanDefinitionRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableP6DataSource> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.9</microsphere-java.version>
-        <microsphere-logging.version>0.1.18</microsphere-logging.version>
+        <microsphere-logging.version>0.1.17</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.9</microsphere-java.version>
-        <microsphere-logging.version>0.1.17</microsphere-logging.version>
+        <microsphere-logging.version>0.1.18</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/annotation/WebExtensionBeanDefinitionRegistrar.java
@@ -17,7 +17,7 @@
 package io.microsphere.spring.web.annotation;
 
 import io.microsphere.spring.beans.BeanSource;
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.event.WebEventPublisher;
 import io.microsphere.spring.web.metadata.CompositeWebEndpointMappingRegistry;
@@ -50,7 +50,7 @@ import static io.microsphere.spring.web.method.support.DelegatingHandlerMethodAd
  * @see EnableWebExtension
  * @since 1.0.0
  */
-public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebExtension> {
+public class WebExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableWebExtension> {
 
     @Override
     protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/annotation/WebFluxExtensionBeanDefinitionRegistrar.java
@@ -17,6 +17,7 @@
 
 package io.microsphere.spring.webflux.annotation;
 
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
 import io.microsphere.spring.context.annotation.OverrideAnnotationAttributes;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
@@ -50,7 +51,7 @@ import static org.springframework.util.StringUtils.uncapitalize;
  * @see ImportBeanDefinitionRegistrar
  * @since 1.0.0
  */
-class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebFluxExtension> {
+class WebFluxExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableWebFluxExtension> {
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/annotation/WebMvcExtensionBeanDefinitionRegistrar.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.spring.webmvc.annotation;
 
-import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportCandidate;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import io.microsphere.spring.web.annotation.EnableWebExtension;
 import io.microsphere.spring.web.annotation.WebExtensionBeanDefinitionRegistrar;
@@ -59,7 +59,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * @see ReversedProxyHandlerMapping
  * @since 1.0.0
  */
-class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportCandidate<EnableWebMvcExtension> {
+class WebMvcExtensionBeanDefinitionRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableWebMvcExtension> {
 
     private static final Class<? extends HandlerInterceptor>[] ALL_HANDLER_INTERCEPTOR_CLASSES = ofArray(HandlerInterceptor.class);
 


### PR DESCRIPTION
This pull request introduces a key refactoring of the annotation-driven import infrastructure in the `microsphere-spring-context` module. The main focus is to split and clarify responsibilities between import selectors and bean definition registrars, improving code organization, maintainability, and extensibility. It introduces a new abstract class, `AnnotatedBeanCapableImportBeanDefinitionRegistrar`, and updates existing classes to extend from more specific base types. Additionally, the documentation and usage examples in the code have been improved for clarity. The pull request also updates version numbers in the `README.md`.

### Refactoring and Infrastructure Improvements

* Introduced a new abstract base class, `AnnotatedBeanCapableImportBeanDefinitionRegistrar`, to encapsulate annotation-driven `ImportBeanDefinitionRegistrar` logic, separating it from import selector logic and providing a clear extension point for bean definition registration. (`microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java`)
* Updated `ConfigurationBeanBindingRegistrar` and `ConfigurationBeanBindingsRegister` to extend from `AnnotatedBeanCapableImportBeanDefinitionRegistrar` instead of the more generic `AnnotatedBeanCapableImportCandidate`, clarifying their roles as bean definition registrars. (`microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java`, `ConfigurationBeanBindingsRegister.java`) [[1]](diffhunk://#diff-9d97c387287b9cabceb5c97db5b2cb6eeb29858128cf572129817f89e84efe1aL20-R20) [[2]](diffhunk://#diff-9d97c387287b9cabceb5c97db5b2cb6eeb29858128cf572129817f89e84efe1aL94-R94) [[3]](diffhunk://#diff-f01878253aedaa116858e39076dfa096d6e5f3d5b30a03ab32a77e9d7711db2fL19-R19) [[4]](diffhunk://#diff-f01878253aedaa116858e39076dfa096d6e5f3d5b30a03ab32a77e9d7711db2fL33-R33)
* Updated property source loader classes (`AnnotatedPropertySourceLoader`, `DefaultPropertiesPropertySourceLoader`, `DefaultPropertiesPropertySourcesLoader`) to extend from `AnnotatedBeanCapableImportSelector`, making their import selector role explicit. (`microsphere-spring-context/src/main/java/io/microsphere/spring/config/context/annotation/AnnotatedPropertySourceLoader.java`, `DefaultPropertiesPropertySourceLoader.java`, `DefaultPropertiesPropertySourcesLoader.java`) [[1]](diffhunk://#diff-145473f78e2df1dea08ebfaf503c6d2c735c9889c5d475f3ddfa0122c8c445d0L21-R21) [[2]](diffhunk://#diff-145473f78e2df1dea08ebfaf503c6d2c735c9889c5d475f3ddfa0122c8c445d0L67-R67) [[3]](diffhunk://#diff-a86b258602c0041225f79c9acfaa67960f7b3b01f4de762c9d230afa68147561L19-R19) [[4]](diffhunk://#diff-a86b258602c0041225f79c9acfaa67960f7b3b01f4de762c9d230afa68147561L46-R46) [[5]](diffhunk://#diff-4e9c37b66dbc623e1119f4986440fb289c5a6497c0075b7b8780e39a4a9828b2L19-R19) [[6]](diffhunk://#diff-4e9c37b66dbc623e1119f4986440fb289c5a6497c0075b7b8780e39a4a9828b2L39-R39)

### Documentation and API Clarity

* Improved in-code documentation and usage examples for `AnnotatedBeanCapableImportCandidate`, focusing on clearer guidance for both import selectors and bean definition registrars, and removed registrar-specific methods from this base class. (`microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java`) [[1]](diffhunk://#diff-a32ffba59fb5ba4913c8782abfba8c7cabcd1a0dd9c5bf8d1053e3be4131594dL22-R35) [[2]](diffhunk://#diff-a32ffba59fb5ba4913c8782abfba8c7cabcd1a0dd9c5bf8d1053e3be4131594dL58-R78) [[3]](diffhunk://#diff-a32ffba59fb5ba4913c8782abfba8c7cabcd1a0dd9c5bf8d1053e3be4131594dL126-L159)

### Version Updates

* Updated the latest version numbers for both `main` and `1.x` branches in `README.md` to reflect the new release. (`README.md`)