### PR TITLE
Standardize Javadoc headings and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | `0.2.33`       |
-| `1.x`  | 4.3.x – 5.3.x                  | `0.1.33`       |
+| `main` | 6.0.x – 7.0.x                  | `0.2.34`       |
+| `1.x`  | 4.3.x – 5.3.x                  | `0.1.34`       |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/DelegatingFactoryBean.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/DelegatingFactoryBean.java
@@ -48,7 +48,7 @@ import static org.springframework.aop.support.AopUtils.getTargetClass;
  *       {@link BeanNameAware}, delegating calls to the target object if applicable.</li>
  * </ul>
  *
- * <h3>Usage Example:</h3>
+ * <h3>Example Usage</h3>
  *
  * <pre>{@code
  * MyService myService = new MyServiceImpl();

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/cache/intereptor/TTLCacheResolver.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/cache/intereptor/TTLCacheResolver.java
@@ -16,7 +16,6 @@
  */
 package io.microsphere.spring.cache.intereptor;
 
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.cache.TTLContext;
 import io.microsphere.spring.cache.annotation.TTLCachePut;
 import io.microsphere.spring.cache.annotation.TTLCacheable;
@@ -45,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.collection.ListUtils.newLinkedList;
 import static io.microsphere.collection.Maps.ofMap;
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.core.annotation.AnnotationUtils.getAnnotationAttributes;
 import static io.microsphere.util.ArrayUtils.isEmpty;
 import static java.time.Duration.ofMillis;
@@ -58,9 +56,7 @@ import static java.util.Collections.emptyList;
  * @since 1.0.0
  */
 public class TTLCacheResolver extends OnceApplicationContextEventListener<ContextRefreshedEvent> implements CacheResolver {
-
-    private static final Logger logger = getLogger(TTLCacheResolver.class);
-
+    
     public static final String BEAN_NAME = "ttlCacheResolver";
 
     private static final Map<Class<? extends CacheOperation>, Class<? extends Annotation>> ttlAnnotationTypes = ofMap(

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/cache/intereptor/TTLCacheResolver.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/cache/intereptor/TTLCacheResolver.java
@@ -56,7 +56,7 @@ import static java.util.Collections.emptyList;
  * @since 1.0.0
  */
 public class TTLCacheResolver extends OnceApplicationContextEventListener<ContextRefreshedEvent> implements CacheResolver {
-    
+
     public static final String BEAN_NAME = "ttlCacheResolver";
 
     private static final Map<Class<? extends CacheOperation>, Class<? extends Annotation>> ttlAnnotationTypes = ofMap(

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportBeanDefinitionRegistrar.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Annotation;
  * This class extends {@link AnnotatedBeanCapableImportCandidate} to provide annotation-driven import capabilities
  * and implements {@link ImportBeanDefinitionRegistrar} to handle bean definition registration.
  *
- * <h3>Usage Example</h3>
+ * <h3>Example Usage</h3>
  * <pre>{@code
  * public class MyFeatureRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableMyFeature> {
  *

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportCandidate.java
@@ -46,7 +46,7 @@ import static org.springframework.core.ResolvableType.forType;
  *     <li>Provides resolved annotation attributes via {@link ResolvablePlaceholderAnnotationAttributes}.</li>
  * </ul>
  *
- * <h3>Usage Example</h3>
+ * <h3>Example Usage</h3>
  * <pre>{@code
  * // 1. Define your custom annotation
  * @Target(ElementType.TYPE)

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportSelector.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/annotation/AnnotatedBeanCapableImportSelector.java
@@ -35,7 +35,7 @@ import static io.microsphere.util.ArrayUtils.EMPTY_STRING_ARRAY;
  * for handling annotated bean capabilities and implements {@link ImportSelector} to integrate
  * with Spring's import mechanism.
  *
- * <h3>Usage Example</h3>
+ * <h3>Example Usage</h3>
  * Suppose you want to create an import selector for an annotation {@code @EnableMyFeature}:
  *
  * <pre>{@code

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/net/AbstractSpringResourceURLConnection.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/net/AbstractSpringResourceURLConnection.java
@@ -161,7 +161,7 @@ public class AbstractSpringResourceURLConnection extends URLConnection {
         Set<Entry<String, List<String>>> entries = headers.entrySet();
         Iterator<Entry<String, List<String>>> iterator = entries.iterator();
         Entry<String, List<String>> entry = null;
-        for (int i = 0; i <= n & iterator.hasNext(); i++) {
+        for (int i = 0; i <= n && iterator.hasNext(); i++) {
             entry = iterator.next();
         }
         return entry;

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.14</microsphere-java.version>
-        <microsphere-logging.version>0.1.20</microsphere-logging.version>
+        <microsphere-logging.version>0.1.21</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -129,7 +129,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
         </dependencies>
     </dependencyManagement>
 

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.13</microsphere-java.version>
+        <microsphere-java.version>0.3.14</microsphere-java.version>
         <microsphere-logging.version>0.1.20</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.13</microsphere-java.version>
-        <microsphere-logging.version>0.1.19</microsphere-logging.version>
+        <microsphere-logging.version>0.1.20</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.11</microsphere-java.version>
+        <microsphere-java.version>0.3.13</microsphere-java.version>
         <microsphere-logging.version>0.1.19</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/method/support/DelegatingHandlerMethodAdvice.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/method/support/DelegatingHandlerMethodAdvice.java
@@ -16,7 +16,6 @@
  */
 package io.microsphere.spring.web.method.support;
 
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.context.event.OnceApplicationContextEventListener;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -26,7 +25,6 @@ import org.springframework.web.method.HandlerMethod;
 
 import java.util.List;
 
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 import static java.util.Collections.emptyList;
 
@@ -43,9 +41,7 @@ public class DelegatingHandlerMethodAdvice extends OnceApplicationContextEventLi
         implements HandlerMethodAdvice {
 
     public static final String BEAN_NAME = "delegatingHandlerMethodAdvice";
-
-    private static final Logger logger = getLogger(DelegatingHandlerMethodAdvice.class);
-
+    
     private List<HandlerMethodArgumentInterceptor> argumentInterceptors = emptyList();
 
     private List<HandlerMethodInterceptor> methodInterceptors = emptyList();

--- a/microsphere-spring-web/src/main/java/io/microsphere/spring/web/method/support/DelegatingHandlerMethodAdvice.java
+++ b/microsphere-spring-web/src/main/java/io/microsphere/spring/web/method/support/DelegatingHandlerMethodAdvice.java
@@ -41,7 +41,7 @@ public class DelegatingHandlerMethodAdvice extends OnceApplicationContextEventLi
         implements HandlerMethodAdvice {
 
     public static final String BEAN_NAME = "delegatingHandlerMethodAdvice";
-    
+
     private List<HandlerMethodArgumentInterceptor> argumentInterceptors = emptyList();
 
     private List<HandlerMethodInterceptor> methodInterceptors = emptyList();

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
@@ -17,7 +17,6 @@
 package io.microsphere.spring.webflux.method;
 
 import io.microsphere.annotation.Nullable;
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.context.event.OnceApplicationContextEventListener;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
 import io.microsphere.spring.web.metadata.WebEndpointMapping;
@@ -51,7 +50,6 @@ import java.util.Map;
 
 import static io.microsphere.collection.MapUtils.newHashMap;
 import static io.microsphere.lang.function.ThrowableAction.execute;
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.reflect.FieldUtils.getFieldValue;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 import static io.microsphere.spring.web.util.MonoUtils.getValue;
@@ -82,9 +80,7 @@ public class InterceptingHandlerMethodProcessor extends OnceApplicationContextEv
         Ordered {
 
     public static final String BEAN_NAME = "interceptingHandlerMethodProcessor";
-
-    private static final Logger logger = getLogger(InterceptingHandlerMethodProcessor.class);
-
+    
     private static final RequestContextWebFilter delegateWebFilter = new RequestContextWebFilter();
 
     private final Map<MethodParameter, MethodParameterContext> parameterContextsCache = newHashMap(256);

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
@@ -80,7 +80,7 @@ public class InterceptingHandlerMethodProcessor extends OnceApplicationContextEv
         Ordered {
 
     public static final String BEAN_NAME = "interceptingHandlerMethodProcessor";
-    
+
     private static final RequestContextWebFilter delegateWebFilter = new RequestContextWebFilter();
 
     private final Map<MethodParameter, MethodParameterContext> parameterContextsCache = newHashMap(256);

--- a/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/method/support/InterceptingHandlerMethodProcessor.java
+++ b/microsphere-spring-webmvc/src/main/java/io/microsphere/spring/webmvc/method/support/InterceptingHandlerMethodProcessor.java
@@ -17,7 +17,6 @@
 package io.microsphere.spring.webmvc.method.support;
 
 import io.microsphere.annotation.Nullable;
-import io.microsphere.logging.Logger;
 import io.microsphere.spring.context.event.OnceApplicationContextEventListener;
 import io.microsphere.spring.web.event.WebEndpointMappingsReadyEvent;
 import io.microsphere.spring.web.metadata.WebEndpointMapping;
@@ -51,7 +50,6 @@ import java.util.Map;
 
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.collection.MapUtils.newHashMap;
-import static io.microsphere.logging.LoggerFactory.getLogger;
 import static io.microsphere.spring.beans.BeanUtils.getSortedBeans;
 import static io.microsphere.spring.web.util.RequestAttributesUtils.getHandlerMethodArguments;
 import static io.microsphere.spring.web.util.WebUtils.isNoArgumentHandlerMethod;
@@ -75,8 +73,6 @@ public class InterceptingHandlerMethodProcessor extends OnceApplicationContextEv
         implements HandlerMethodArgumentResolver, HandlerMethodReturnValueHandler, HandlerInterceptor, WebMvcConfigurerAdapter {
 
     public static final String BEAN_NAME = "interceptingHandlerMethodProcessor";
-
-    private static final Logger logger = getLogger(InterceptingHandlerMethodProcessor.class);
 
     private final Map<MethodParameter, MethodParameterContext> parameterContextsCache = newHashMap(256);
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.5</version>
+        <version>0.3.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.6</version>
+        <version>0.3.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes minor updates to documentation formatting and dependency versions. The most significant changes are version bumps for dependencies and improvements to the consistency of documentation headers.

Dependency version updates:

* Updated the `microsphere-java.version` property from `0.3.11` to `0.3.13` in `microsphere-spring-parent/pom.xml` to use the latest version of the Java dependency.
* Updated the parent project version from `0.3.5` to `0.3.6` in `pom.xml`.

Documentation consistency improvements:

* Standardized the "Usage Example" section header to "Example Usage" in the Javadoc for `DelegatingFactoryBean`, `AnnotatedBeanCapableImportBeanDefinitionRegistrar`, `AnnotatedBeanCapableImportCandidate`, and `AnnotatedBeanCapableImportSelector` for improved clarity and consistency. [[1]](diffhunk://#diff-a72ad2ae7721af511b6cda04667d2716f8a76fa9c6ae5a233db5b9f3ff7d79aaL51-R51) [[2]](diffhunk://#diff-68c3fce5dcff3b5dbc7cffe514a509fc1261cc2cbb3808d275243221d7cf4b95L36-R36) [[3]](diffhunk://#diff-a32ffba59fb5ba4913c8782abfba8c7cabcd1a0dd9c5bf8d1053e3be4131594dL49-R49) [[4]](diffhunk://#diff-6e01a36c54b22463dbc5b135a7869dd7abfa3ab80d8a5230e8e81a81e600f96dL38-R38)