### PR TITLE
Update parent POM and dependencies to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | `0.2.34`       |
-| `1.x`  | 4.3.x – 5.3.x                  | `0.1.34`       |
+| `main` | 6.0.x – 7.0.x                  | `0.2.35`       |
+| `1.x`  | 4.3.x – 5.3.x                  | `0.1.35`       |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.15</microsphere-java.version>
-        <microsphere-logging.version>0.1.21</microsphere-logging.version>
+        <microsphere-logging.version>0.1.22</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.14</microsphere-java.version>
+        <microsphere-java.version>0.3.15</microsphere-java.version>
         <microsphere-logging.version>0.1.21</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.7</version>
+        <version>0.3.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates dependency versions in the Maven configuration files to ensure the project uses the latest compatible releases.

Dependency version updates:

* Updated the parent project version in `pom.xml` from `0.3.7` to `0.3.8`, aligning with the latest build configuration.
* Bumped `microsphere-java` from `0.3.14` to `0.3.15` and `microsphere-logging` from `0.1.21` to `0.1.22` in `microsphere-spring-parent/pom.xml` to incorporate recent improvements and fixes.