### PR TITLE
Upgrade and align microsphere-logging dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Choose the version that matches your Spring Framework line:
 
 | Branch | Spring Framework compatibility | Latest version |
 |--------|--------------------------------|----------------|
-| `main` | 6.0.x – 7.0.x                  | `0.2.35`       |
-| `1.x`  | 4.3.x – 5.3.x                  | `0.1.35`       |
+| `main` | 6.0.x – 7.0.x                  | `0.2.36`       |
+| `1.x`  | 4.3.x – 5.3.x                  | `0.1.36`       |
 
 ### 2. Add individual modules
 

--- a/microsphere-spring-context/pom.xml
+++ b/microsphere-spring-context/pom.xml
@@ -58,13 +58,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- SLF4j API -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/microsphere-spring-context/pom.xml
+++ b/microsphere-spring-context/pom.xml
@@ -20,10 +20,10 @@
 
     <dependencies>
 
-        <!-- Java Common Annotations -->
+        <!-- Microsphere Annotation Processor -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -58,6 +58,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Java Common Annotations -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -75,13 +82,6 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Microsphere Annotation Processor -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/BeanSource.java
@@ -128,7 +128,7 @@ public enum BeanSource {
      * and registers them as generic beans. The underlying {@link ConfigurableListableBeanFactory} is derived
      * from the provided registry for type resolution if necessary.
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories source
      * BeanDefinitionRegistry registry = ...;
@@ -165,7 +165,7 @@ public enum BeanSource {
      * and registers them as generic beans. The underlying {@link BeanDefinitionRegistry} is derived
      * from the provided {@link ConfigurableListableBeanFactory}.
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories source
      * ConfigurableListableBeanFactory beanFactory = ...;
@@ -200,7 +200,7 @@ public enum BeanSource {
      * This method discovers bean classes for the specified {@code beanTypes} using this {@link BeanSource},
      * and registers them as generic beans.
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories source
      * ConfigurableListableBeanFactory beanFactory = ...;
@@ -269,7 +269,7 @@ public enum BeanSource {
      * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
      * may override earlier ones if the bean name conflicts).
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories and Java Service Provider sources
      * ConfigurableListableBeanFactory beanFactory = ...;
@@ -310,7 +310,7 @@ public enum BeanSource {
      * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
      * may override earlier ones if the bean name conflicts).
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories and Java Service Provider sources
      * BeanDefinitionRegistry registry = ...;
@@ -350,7 +350,7 @@ public enum BeanSource {
      * the behavior depends on the underlying {@link BeanDefinitionRegistry} implementation (typically, later registrations
      * may override earlier ones if the bean name conflicts).
      *
-     * <h3>Example Usage:</h3>
+     * <h3>Example Usage</h3>
      * <pre>{@code
      * // Register beans from Spring Factories and Java Service Provider sources
      * ConfigurableListableBeanFactory beanFactory = ...;

--- a/microsphere-spring-jdbc/pom.xml
+++ b/microsphere-spring-jdbc/pom.xml
@@ -20,6 +20,20 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Spring Context -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-context</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
         <!-- Spring Framework -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -33,13 +47,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Microsphere Spring Context -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-context</artifactId>
-            <version>${revision}</version>
-        </dependency>
-
         <!-- JDBC -->
         <dependency>
             <groupId>p6spy</groupId>
@@ -48,24 +55,24 @@
         </dependency>
 
         <!-- Testing -->
-
-        <!-- Microsphere Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
-            <version>${revision}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Test -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 
@@ -76,6 +83,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Logback -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/microsphere-spring-jdbc/pom.xml
+++ b/microsphere-spring-jdbc/pom.xml
@@ -47,13 +47,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- SLF4j API -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Testing -->
 
         <!-- Microsphere Spring Test -->

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.15</microsphere-java.version>
-        <microsphere-logging.version>0.1.23</microsphere-logging.version>
+        <microsphere-logging.version>0.1.22</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.15</microsphere-java.version>
-        <microsphere-logging.version>0.1.22</microsphere-logging.version>
+        <microsphere-logging.version>0.1.23</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-test/pom.xml
+++ b/microsphere-spring-test/pom.xml
@@ -20,6 +20,13 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Java Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -32,6 +39,7 @@
             <artifactId>microsphere-logging-test</artifactId>
         </dependency>
 
+        <!-- Microsphere Logback -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-logback</artifactId>
@@ -184,7 +192,7 @@
 
         <!-- Testing -->
 
-        <!-- Logging -->
+        <!-- Logback -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/microsphere-spring-web/pom.xml
+++ b/microsphere-spring-web/pom.xml
@@ -68,13 +68,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/microsphere-spring-webflux/pom.xml
+++ b/microsphere-spring-webflux/pom.xml
@@ -62,15 +62,6 @@
         </dependency>
 
         <!-- Testing -->
-
-        <!-- Microsphere Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
-            <version>${revision}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -81,6 +72,14 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-webflux/pom.xml
+++ b/microsphere-spring-webflux/pom.xml
@@ -61,13 +61,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Testing -->
 
         <!-- Microsphere Spring Test -->

--- a/microsphere-spring-webmvc/pom.xml
+++ b/microsphere-spring-webmvc/pom.xml
@@ -69,15 +69,6 @@
         </dependency>
 
         <!-- Testing -->
-
-        <!-- Microsphere Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
-            <version>${revision}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -88,6 +79,14 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-spring-webmvc/pom.xml
+++ b/microsphere-spring-webmvc/pom.xml
@@ -68,13 +68,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Testing -->
 
         <!-- Microsphere Spring Test -->


### PR DESCRIPTION
This pull request removes the optional `slf4j-api` dependency from several module `pom.xml` files. This change helps to simplify the dependency tree and avoid redundant or unnecessary logging dependencies in these modules.

**Dependency cleanup:**

* Removed the optional `org.slf4j:slf4j-api` dependency from the following module `pom.xml` files:
  * `microsphere-spring-context/pom.xml`
  * `microsphere-spring-jdbc/pom.xml`
  * `microsphere-spring-web/pom.xml`
  * `microsphere-spring-webflux/pom.xml`
  * `microsphere-spring-webmvc/pom.xml`