### PR TITLE
Dev 1.x

### DIFF
--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/BeanFactoryUtils.java
@@ -492,7 +492,7 @@ public abstract class BeanFactoryUtils implements Utils {
      */
     @Nonnull
     public static Set<Class<?>> getResolvableDependencyTypes(DefaultListableBeanFactory beanFactory) {
-        Map<Class<?>, Object> resolvableDependencies = getFieldValue(beanFactory, "resolvableDependencies", Map.class);
+        Map<Class<?>, Object> resolvableDependencies = getFieldValue(true, beanFactory, "resolvableDependencies", Map.class);
         return ofSet(resolvableDependencies);
     }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/beans/factory/annotation/AnnotatedInjectionBeanPostProcessor.java
@@ -789,7 +789,7 @@ public class AnnotatedInjectionBeanPostProcessor extends InstantiationAwareBeanP
             } else {
                 value = resolveFieldValue(field, bean, beanName, pvs);
             }
-            setFieldValue(bean, field, value);
+            setFieldValue(true, bean, field, value);
         }
 
         @Nullable
@@ -860,7 +860,7 @@ public class AnnotatedInjectionBeanPostProcessor extends InstantiationAwareBeanP
                 arguments = resolveMethodArguments(method, bean, beanName, pvs);
             }
             if (arguments != null) {
-                invokeMethod(bean, method, arguments);
+                invokeMethod(true, bean, method, arguments);
             }
         }
 

--- a/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventPublishingBeanBeforeProcessor.java
+++ b/microsphere-spring-context/src/main/java/io/microsphere/spring/context/event/EventPublishingBeanBeforeProcessor.java
@@ -207,6 +207,6 @@ class EventPublishingBeanBeforeProcessor extends InstantiationAwareBeanPostProce
     }
 
     private InstantiationStrategy getInstantiationStrategyDelegate(ConfigurableListableBeanFactory beanFactory) {
-        return invokeMethod(beanFactory, getInstantiationStrategyMethod);
+        return invokeMethod(true, beanFactory, getInstantiationStrategyMethod);
     }
 }

--- a/microsphere-spring-context/src/test/java/io/microsphere/spring/net/AbstractSpringResourceURLConnectionTest.java
+++ b/microsphere-spring-context/src/test/java/io/microsphere/spring/net/AbstractSpringResourceURLConnectionTest.java
@@ -265,7 +265,7 @@ public abstract class AbstractSpringResourceURLConnectionTest {
     void testIfModifiedSince(URLConnection urlConnection) throws IOException {
         long ifModifiedSince = urlConnection.getIfModifiedSince();
         String connectedFieldName = "connected";
-        boolean connected = getFieldValue(urlConnection, connectedFieldName, boolean.class);
+        boolean connected = getFieldValue(true, urlConnection, connectedFieldName, boolean.class);
         try {
             assertEquals(0, ifModifiedSince);
             long currentTimeMillis = currentTimeMillis();
@@ -277,7 +277,7 @@ public abstract class AbstractSpringResourceURLConnectionTest {
         } catch (IllegalStateException e) {
             assertNotNull(e);
         } finally {
-            setFieldValue(urlConnection, connectedFieldName, connected);
+            setFieldValue(true, urlConnection, connectedFieldName, connected);
             urlConnection.setIfModifiedSince(ifModifiedSince);
         }
     }
@@ -305,13 +305,13 @@ public abstract class AbstractSpringResourceURLConnectionTest {
 
     void testConnect(URLConnection urlConnection) throws IOException {
         String connectedFieldName = "connected";
-        boolean connected = getFieldValue(urlConnection, connectedFieldName, boolean.class);
+        boolean connected = getFieldValue(true, urlConnection, connectedFieldName, boolean.class);
         try {
             assertFalse(connected);
             urlConnection.connect();
-            assertTrue(getFieldValue(urlConnection, connectedFieldName, boolean.class));
+            assertTrue(getFieldValue(true, urlConnection, connectedFieldName, boolean.class));
         } finally {
-            setFieldValue(urlConnection, connectedFieldName, connected);
+            setFieldValue(true, urlConnection, connectedFieldName, connected);
         }
     }
 

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.15</microsphere-java.version>
+        <microsphere-java.version>0.3.16</microsphere-java.version>
         <microsphere-logging.version>0.1.22</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.16</microsphere-java.version>
-        <microsphere-logging.version>0.1.22</microsphere-logging.version>
+        <microsphere-logging.version>0.1.23</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
@@ -246,8 +246,8 @@ public enum RequestPredicateKind {
         }
 
         RequestPredicate getDelegate(RequestPredicate requestPredicate) {
-            RequestPredicate delegate = getFieldValue(requestPredicate, "arg$1");
-            return delegate == null ? getFieldValue(requestPredicate, "delegate") : delegate;
+            RequestPredicate delegate = getFieldValue(true, requestPredicate, "arg$1");
+            return delegate == null ? getFieldValue(true, requestPredicate, "delegate") : delegate;
         }
     },
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
@@ -141,11 +141,11 @@ public enum RequestPredicateKind {
         }
 
         RequestPredicate left(RequestPredicate predicate) {
-            return getFieldValue(predicate, "left");
+            return getFieldValue(true, predicate, "left");
         }
 
         RequestPredicate right(RequestPredicate predicate) {
-            return getFieldValue(predicate, "right");
+            return getFieldValue(true, predicate, "right");
         }
     },
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateKind.java
@@ -199,11 +199,11 @@ public enum RequestPredicateKind {
         }
 
         RequestPredicate left(RequestPredicate predicate) {
-            return getFieldValue(predicate, "left");
+            return getFieldValue(true, predicate, "left");
         }
 
         RequestPredicate right(RequestPredicate predicate) {
-            return getFieldValue(predicate, "right");
+            return getFieldValue(true, predicate, "right");
         }
     },
 

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateVisitorAdapter.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/function/server/RequestPredicateVisitorAdapter.java
@@ -241,7 +241,7 @@ public interface RequestPredicateVisitorAdapter extends InvocationHandler {
     default void visit(RequestPredicate predicate) {
         if (isVisitorSupported()) {
             Object visitor = getProxy();
-            invokeMethod(predicate, ACCEPT_METHOD, visitor);
+            invokeMethod(true, predicate, ACCEPT_METHOD, visitor);
         } else {
             acceptVisitor(predicate, this);
         }

--- a/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
+++ b/microsphere-spring-webflux/src/main/java/io/microsphere/spring/webflux/method/InterceptingHandlerMethodProcessor.java
@@ -244,12 +244,12 @@ public class InterceptingHandlerMethodProcessor extends OnceApplicationContextEv
 
     private List<HandlerResultHandler> getHandlerResultHandlers(ApplicationContext context) {
         DispatcherHandler dispatcherHandler = context.getBean(DispatcherHandler.class);
-        return getFieldValue(dispatcherHandler, "resultHandlers");
+        return getFieldValue(true, dispatcherHandler, "resultHandlers");
     }
 
     private List<HandlerMethodArgumentResolver> getHandlerMethodArgumentResolvers(RequestMappingHandlerAdapter adapter) {
-        Object methodResolver = getFieldValue(adapter, "methodResolver");
-        return getFieldValue(methodResolver, "requestMappingResolvers");
+        Object methodResolver = getFieldValue(true, adapter, "methodResolver");
+        return getFieldValue(true, methodResolver, "requestMappingResolvers");
     }
 
     private void initMethodParameterContextsCache(MethodParameter methodParameter, HandlerMethod handlerMethod,

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.8</version>
+        <version>0.3.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.10</version>
+        <version>0.3.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request primarily updates method calls throughout the codebase to consistently pass an explicit `true` parameter to various reflective utility methods like `getFieldValue`, `setFieldValue`, and `invokeMethod`. Additionally, it upgrades the versions of core dependencies in the parent POM files. These changes improve code clarity and ensure consistent behavior when accessing or modifying fields and invoking methods reflectively.

**Dependency version upgrades:**

* Updated `microsphere-java.version` to `0.3.16` and `microsphere-logging.version` to `0.1.23` in `microsphere-spring-parent/pom.xml`.
* Updated parent build version to `0.3.11` in `pom.xml`.

**Consistent reflection utility usage:**

* Added an explicit `true` parameter to all calls to `getFieldValue`, `setFieldValue`, and `invokeMethod` across the codebase, affecting files such as `BeanFactoryUtils.java`, `AnnotatedInjectionBeanPostProcessor.java`, `EventPublishingBeanBeforeProcessor.java`, `AbstractSpringResourceURLConnectionTest.java`, `RequestPredicateKind.java`, `RequestPredicateVisitorAdapter.java`, and `InterceptingHandlerMethodProcessor.java`. [[1]](diffhunk://#diff-0512a7026772b4c2404eb3886fa7c5dbc47def7090773de8be53d3d6b550fb96L495-R495) [[2]](diffhunk://#diff-0c2b721469dcc3c2477686ea54057610f04177073014f89f3eb9b0f088bc6d0aL792-R792) [[3]](diffhunk://#diff-0c2b721469dcc3c2477686ea54057610f04177073014f89f3eb9b0f088bc6d0aL863-R863) [[4]](diffhunk://#diff-67af5861a84e43d953a5dcba2e9c796227dcdbf44d9deb5d6e10220dcf8849a2L210-R210) [[5]](diffhunk://#diff-1dc22471eb7c4b11ebf85f1767851a8e4c9bd69418307738fa23eb09b69ce371L268-R268) [[6]](diffhunk://#diff-1dc22471eb7c4b11ebf85f1767851a8e4c9bd69418307738fa23eb09b69ce371L280-R280) [[7]](diffhunk://#diff-1dc22471eb7c4b11ebf85f1767851a8e4c9bd69418307738fa23eb09b69ce371L308-R314) [[8]](diffhunk://#diff-d842be6c28329b8d6db8868c73f26d7083c54af4f16350f4ca1fc929c068e61aL144-R148) [[9]](diffhunk://#diff-d842be6c28329b8d6db8868c73f26d7083c54af4f16350f4ca1fc929c068e61aL202-R206) [[10]](diffhunk://#diff-d842be6c28329b8d6db8868c73f26d7083c54af4f16350f4ca1fc929c068e61aL249-R250) [[11]](diffhunk://#diff-0343d5437d95573a49efa424c85b384baab93d0e9139dabb1920f171bdd2a7ddL244-R244) [[12]](diffhunk://#diff-19328ffe056926468e635ac8689c8b4df2b12e96b571842683efc9439f9e602bL247-R252)

These changes help ensure that reflective operations are performed with the intended behavior throughout the project.