### PR TITLE
Bump microsphere-java to version 0.3.17 for updates and fixes

### DIFF
--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -19,7 +19,7 @@
     <description>Microsphere Spring Parent</description>
 
     <properties>
-        <microsphere-java.version>0.3.16</microsphere-java.version>
+        <microsphere-java.version>0.3.17</microsphere-java.version>
         <microsphere-logging.version>0.1.23</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/microsphere-spring-parent/pom.xml
+++ b/microsphere-spring-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <microsphere-java.version>0.3.17</microsphere-java.version>
-        <microsphere-logging.version>0.1.23</microsphere-logging.version>
+        <microsphere-logging.version>0.2.0</microsphere-logging.version>
         <jackson.version>2.21.3</jackson.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <p6spy.version>3.9.1</p6spy.version>


### PR DESCRIPTION
This pull request updates the `microsphere-java` dependency version in the `microsphere-spring-parent/pom.xml` file.

Dependency updates:

* Bumped the `microsphere-java.version` property from `0.3.16` to `0.3.17` to use the latest version of the dependency.Updates the parent POM property to use microsphere-java 0.3.17, pulling in the latest fixes and improvements from that dependency.